### PR TITLE
Quickstart changes: native install needs to wget amdgpu_install deb or rpm, to get .list files

### DIFF
--- a/docs/tutorial/quick-start.rst
+++ b/docs/tutorial/quick-start.rst
@@ -13,17 +13,17 @@ To start, choose your preferred install method and operating system:
 .. grid:: 2
     :gutter: 1
 
-    .. grid-item-card:: :ref:`rocm-amdgpu-quick`
-
-        * :ref:`amdgpu-ubuntu`
-        * :ref:`amdgpu-rhel`
-        * :ref:`amdgpu-suse`
-
     .. grid-item-card:: :ref:`rocm-package-man-quick`
 
         * :ref:`package-man-ubuntu`
         * :ref:`package-man-rhel`
         * :ref:`package-man-suse`
+        
+    .. grid-item-card:: :ref:`rocm-amdgpu-quick`
+
+        * :ref:`amdgpu-ubuntu`
+        * :ref:`amdgpu-rhel`
+        * :ref:`amdgpu-suse`
 
 .. _rocm-package-man-quick:
 
@@ -48,6 +48,8 @@ Ubuntu
                 sudo apt install "linux-headers-$(uname -r)" "linux-modules-extra-$(uname -r)"
                 # See prerequisites. Adding current user to Video and Render groups
                 sudo usermod -a -G render,video $LOGNAME
+                wget https://repo.radeon.com/amdgpu-install/|amdgpu_version|/ubuntu/{{ os_release }}/amdgpu-install_|amdgpu_install_version|_all.deb
+                sudo apt install ./amdgpu-install_|amdgpu_install_version|_all.deb
                 sudo apt update
                 sudo apt install amdgpu-dkms
                 sudo apt install rocm-hip-libraries
@@ -75,6 +77,7 @@ Red Hat Enterprise Linux
                 sudo yum install kernel-headers kernel-devel
                 # See prerequisites. Adding current user to Video and Render groups
                 sudo usermod -a -G render,video $LOGNAME
+                sudo yum install https://repo.radeon.com/amdgpu-install/|amdgpu_version|/rhel/{{ os_version }}/amdgpu-install-|amdgpu_install_version|.el{{ os_release }}.noarch.rpm 
                 sudo yum clean all
                 sudo yum install amdgpu-dkms
                 sudo yum install rocm-hip-libraries
@@ -101,6 +104,7 @@ SUSE Linux Enterprise Server
                 sudo zypper install kernel-default-devel
                 # See prerequisites. Adding current user to Video and Render groups
                 sudo usermod -a -G render,video $LOGNAME
+                sudo zypper --no-gpg-checks install https://repo.radeon.com/amdgpu-install/|amdgpu_version|/sle/{{ os_version }}/amdgpu-install-|amdgpu_install_version|.noarch.rpm
                 sudo zypper refresh
                 sudo zypper install amdgpu-dkms
                 sudo zypper install rocm-hip-libraries
@@ -130,7 +134,7 @@ Ubuntu
                 sudo apt update
                 wget https://repo.radeon.com/amdgpu-install/|amdgpu_version|/ubuntu/{{ os_release }}/amdgpu-install_|amdgpu_install_version|_all.deb
                 sudo apt install ./amdgpu-install_|amdgpu_install_version|_all.deb
-                sudo amdgpu-install --usecase=rocm
+                sudo amdgpu-install --usecase=graphics,rocm
         {% endfor %}
 
 .. _amdgpu-rhel:
@@ -149,7 +153,7 @@ Red Hat Enterprise Linux
                 :substitutions:
 
                 sudo yum install https://repo.radeon.com/amdgpu-install/|amdgpu_version|/rhel/{{ os_version }}/amdgpu-install-|amdgpu_install_version|.el{{ os_release }}.noarch.rpm 
-                sudo amdgpu-install --usecase=rocm
+                sudo amdgpu-install --usecase=graphics,rocm
         {% endfor %}
 
 .. _amdgpu-suse:
@@ -168,5 +172,5 @@ SUSE Linux Enterprise Server
                 :substitutions:
 
                 sudo zypper --no-gpg-checks install https://repo.radeon.com/amdgpu-install/|amdgpu_version|/sle/{{ os_version }}/amdgpu-install-|amdgpu_install_version|.noarch.rpm
-                sudo amdgpu-install --usecase=rocm
+                sudo amdgpu-install --usecase=graphics,rocm
         {% endfor %}


### PR DESCRIPTION
Quickstart Install changes:
- Native install needs to put back the wget of amdgpu_install deb or rpm (revert of #24).  That is how the repo.list files get on the system, otherwise native install just fails.
- AMDGPU-install should re-add graphics to usecases.  
- I switched the panel order to show Native first, then AMDGPU as second, to flow with page layout
- In native install, sudo apt install rocm-hip-libraries can be changed to sudo apt install rocm now, but needs more testing first.