### PR TITLE
docs(3rd-party-support-matrix.rs): correct thrust/cub compatibility version

### DIFF
--- a/docs/reference/3rd-party-support-matrix.rst
+++ b/docs/reference/3rd-party-support-matrix.rst
@@ -152,7 +152,7 @@ CUDA/NVIDIA HPC SDK alternatives.
       - 22.9
 
     * - 6.0.x
-      - 3.0.0
+      - 2.0.1
       - 22.9
 
 For the latest documentation of these libraries, refer to the


### PR DESCRIPTION
In ROCm 6.0 rocThrust/hipCUB 3.0.0 is compatible with thrust/CUB 2.0.1. The version number in the documentation should reference the Nvidia libraries and not the ROCm libraries.

Please refer to the changelog in rocThrust & hipCUB:

- https://github.com/ROCm/rocThrust/blob/develop/CHANGELOG.md#rocthrust-300-for-rocm-60
- https://github.com/ROCm/hipCUB/blob/develop/CHANGELOG.md#hipcub-2132-for-rocm-570

This commit should also be cherry-picked to the `docs/6.0.0` branch.