### PR TITLE
Add rocm_directory_version to the rst prolog

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -71,6 +71,7 @@ external_projects_current_project = "rocm"
 rst_prolog = f"""
 .. |rocm_version| replace:: {rocm_version}
 .. |amdgpu_version| replace:: {amdgpu_version}
+.. |rocm_directory_version| replace:: {rocm_directory_version}
 .. |amdgpu_install_version| replace:: {amdgpu_install_version}
 """
 


### PR DESCRIPTION
Fix minor oversight in https://github.com/ROCm/rocm-install-on-linux/pull/53