### PR TITLE
Support for WSL2 and Docker Desktop for Windows

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -36,6 +36,7 @@ rhel_version_numbers = [('9', '9.3'), ('9', '9.2'), ('8', '8.9'), ('8', '8.8')]
 sles_version_numbers = ['15.5', '15.4']
 ol_release_version_numbers = ['8']
 ol_version_numbers = [('8', '8.8')]
+ubuntu_wsl2_docker_desktop_win_version_numbers = [('22.04', 'jammy')]
 
 # pages with specific settings
 article_pages = [
@@ -85,5 +86,6 @@ html_context = {
     "rhel_release_version_numbers" : rhel_release_version_numbers,
     "rhel_version_numbers" : rhel_version_numbers,
     "ol_release_version_numbers" : ol_release_version_numbers,
-    "ol_version_numbers" : ol_version_numbers
+    "ol_version_numbers" : ol_version_numbers,
+    "ubuntu_wsl2_docker_desktop_win_version_numbers": ubuntu_wsl2_docker_desktop_win_version_numbers
 }

--- a/docs/how-to/amdgpu-install.rst
+++ b/docs/how-to/amdgpu-install.rst
@@ -90,6 +90,24 @@ SUSE Linux Enterprise
                 sudo zypper --no-gpg-checks install https://repo.radeon.com/amdgpu-install/|amdgpu_version|/sle/{{ os_version }}/amdgpu-install-|amdgpu_install_version|.noarch.rpm
         {% endfor %}
 
+Ubuntu (WSL2 / Docker for Windows)
+--------------------------------------------------------------------
+
+.. datatemplate:nodata::
+
+    .. tab-set::
+        {% for (os_version, os_release) in config.html_context['ubuntu_wsl2_docker_desktop_win_version_numbers'] %}
+        .. tab-item:: {{ os_version }}
+            :sync: ubuntu-wsl2-docker-desktop-win-{{ os_version}}
+
+            .. code-block:: bash
+                :substitutions:
+
+                sudo apt update
+                wget https://repo.radeon.com/amdgpu-install/|amdgpu_version|/ubuntu/{{ os_release }}/amdgpu-install_|amdgpu_install_version|_all.deb
+                sudo apt install ./amdgpu-install_|amdgpu_install_version|_all.deb
+        {% endfor %}
+
 Use cases
 =================================================
 
@@ -128,6 +146,8 @@ output below.
       - HIP runtimes
       - Machine learning framework
       - All ROCm libraries and applications
+    wsl             (for using ROCm in a WSL)
+      - ROCr WSL runtime library (Ubuntu 22.04 only)
     rocmdev         (for developers requiring ROCm runtime and
                     profiling/debugging tools)
       - HIP runtimes
@@ -215,6 +235,13 @@ To install use cases specific to your requirements, use the installer
   .. code-block:: bash
 
     sudo amdgpu-install --usecase=rocm,asan
+
+- To install the WSL2 and Docker Desktop for Windows compatible binaries add
+  ``wsl``. For example:
+
+  .. code-block:: bash
+
+    sudo amdgpu-install --usecase=rocm,wsl --no-dkms --no-32
 
 Uninstalling ROCm
 =================================================

--- a/docs/how-to/amdgpu-install.rst
+++ b/docs/how-to/amdgpu-install.rst
@@ -31,7 +31,7 @@ Ubuntu
 
     .. tab-set::
         {% for (os_version, os_release) in config.html_context['ubuntu_version_numbers'] %}
-        .. tab-item:: Ubuntu {{ os_version }}
+        .. tab-item:: {{ os_version }}
             :sync: ubuntu-{{ os_version}}
 
             .. code-block:: bash
@@ -49,7 +49,7 @@ Red Hat Enterprise Linux
 
     .. tab-set::
         {% for (os_release, os_version) in config.html_context['rhel_version_numbers'] %}
-        .. tab-item:: RHEL {{ os_version }}
+        .. tab-item:: {{ os_version }}
             :sync: rhel-{{ os_version }} rhel-{{ os_release }}
 
             .. code-block:: bash
@@ -65,7 +65,7 @@ Oracle Linux
 
     .. tab-set::
         {% for (os_release, os_version) in config.html_context['ol_version_numbers'] %}
-        .. tab-item:: OL {{ os_version }}
+        .. tab-item:: {{ os_version }}
             :sync: ol-{{ os_version }} ol-{{ os_release }}
 
             .. code-block:: bash
@@ -82,7 +82,7 @@ SUSE Linux Enterprise
 
     .. tab-set::
         {% for os_version in config.html_context['sles_version_numbers'] %}
-        .. tab-item:: SLES {{ os_version }}
+        .. tab-item:: {{ os_version }}
 
             .. code-block:: bash
                 :substitutions:

--- a/docs/how-to/native-install/index.rst
+++ b/docs/how-to/native-install/index.rst
@@ -16,6 +16,7 @@ Installation via native package manager
         - :doc:`Red Hat Enterprise Linux</how-to/native-install/rhel>`
         - :doc:`SUSE Linux Enterprise</how-to/native-install/sles>`
         - :doc:`Oracle Linux</how-to/native-install/ol>`
+        - :doc:`Ubuntu (WSL2 / Docker Desktop for Windows)</how-to/native-install/ubuntu-wsl2-docker-desktop-win>`
 
     .. grid-item-card:: Upgrade
 

--- a/docs/how-to/native-install/index.rst
+++ b/docs/how-to/native-install/index.rst
@@ -15,6 +15,7 @@ Installation via native package manager
         - :doc:`Ubuntu</how-to/native-install/ubuntu>`
         - :doc:`Red Hat Enterprise Linux</how-to/native-install/rhel>`
         - :doc:`SUSE Linux Enterprise</how-to/native-install/sles>`
+        - :doc:`Oracle Linux</how-to/native-install/ol>`
 
     .. grid-item-card:: Upgrade
 

--- a/docs/how-to/native-install/ol.rst
+++ b/docs/how-to/native-install/ol.rst
@@ -19,7 +19,7 @@ Register kernel-mode driver
 
     .. tab-set::
         {% for (os_release, os_version) in config.html_context['ol_version_numbers'] %}
-        .. tab-item:: OL {{ os_version }}
+        .. tab-item:: {{ os_version }}
             :sync: ol-{{ os_version }} ol-{{ os_release }}
 
             .. code-block:: bash
@@ -46,7 +46,7 @@ Register ROCm packages
 
     .. tab-set::
         {% for os_release in config.html_context['ol_release_version_numbers'] %}
-        .. tab-item:: OL {{ os_release }}
+        .. tab-item:: {{ os_release }}
             :sync: ol-{{ os_release }}
 
             .. code-block:: bash

--- a/docs/how-to/native-install/post-install.rst
+++ b/docs/how-to/native-install/post-install.rst
@@ -62,3 +62,9 @@ Post-installation instructions
             .. code-block:: bash
 
                 sudo zypper search --installed-only
+
+         .. tab-item:: Ubuntu (WSL2 / Docker for Windows)
+
+            .. code-block:: bash
+
+                sudo apt list --installed

--- a/docs/how-to/native-install/rhel.rst
+++ b/docs/how-to/native-install/rhel.rst
@@ -19,7 +19,7 @@ Register kernel-mode driver
 
     .. tab-set::
         {% for (os_release, os_version) in config.html_context['rhel_version_numbers'] %}
-        .. tab-item:: RHEL {{ os_version }}
+        .. tab-item:: {{ os_version }}
             :sync: rhel-{{ os_version }} rhel-{{ os_release }}
 
             .. code-block:: bash
@@ -46,7 +46,7 @@ Register ROCm packages
 
     .. tab-set::
         {% for os_release in config.html_context['rhel_release_version_numbers']  %}
-        .. tab-item:: RHEL {{ os_release }}
+        .. tab-item:: {{ os_release }}
             :sync: rhel-{{ os_release }}
 
             .. code-block:: bash

--- a/docs/how-to/native-install/sles.rst
+++ b/docs/how-to/native-install/sles.rst
@@ -20,7 +20,7 @@ Register kernel-mode driver
 
     .. tab-set::
         {% for os_version in config.html_context['sles_version_numbers'] %}
-        .. tab-item:: SLES {{ os_version }}
+        .. tab-item:: {{ os_version }}
 
             .. code-block:: bash
                 :substitutions:

--- a/docs/how-to/native-install/ubuntu-wsl2-docker-desktop-win.rst
+++ b/docs/how-to/native-install/ubuntu-wsl2-docker-desktop-win.rst
@@ -1,0 +1,155 @@
+.. meta::
+  :description: Ubuntu (WSL2 / Docker for Windows) installation
+  :keywords: ROCm install, installation instructions, Ubuntu,
+             Ubuntu (WSL2 / Docker for Windows) installation, AMD, ROCm, WSL,
+             Docker, Docker Desktop for Windows
+
+****************************************************************************
+Ubuntu (WSL2 / Docker for Windows) installation
+****************************************************************************
+
+.. _ubuntu-wsl2-docker-desktop-win-register-repo:
+
+Registering repositories
+=================================================
+
+Package signing key
+---------------------------------------------------------------------------
+
+Download and convert the package signing key.
+
+.. code-block:: bash
+
+    # Make the directory if it doesn't exist yet.
+    # This location is recommended by the distribution maintainers.
+    sudo mkdir --parents --mode=0755 /etc/apt/keyrings
+
+    # Download the key, convert the signing-key to a full
+    # keyring required by apt and store in the keyring directory
+    wget https://repo.radeon.com/rocm/rocm.gpg.key -O - | \
+        gpg --dearmor | sudo tee /etc/apt/keyrings/rocm.gpg > /dev/null
+
+.. _ubuntu-wsl2-docker-desktop-win-register-driver:
+
+.. note::
+    The GPG key may change; ensure it is updated when installing a new release.
+    If the key signature verification fails while updating,
+    re-add the key from the ROCm to the apt repository as mentioned above.
+    The current ``rocm.gpg.key`` is not available in a standard key ring distribution
+    but has the following SHA1 sum hash:
+    ``73f5d8100de6048aa38a8b84cd9a87f05177d208 rocm.gpg.key``
+
+Register ROCm packages
+---------------------------------------------------------------------------
+
+Add the ROCm repository.
+
+.. datatemplate:nodata::
+
+    .. tab-set::
+        {% for (os_version, os_release) in config.html_context['ubuntu_wsl2_docker_desktop_win_version_numbers'] %}
+        .. tab-item:: {{ os_version }}
+            :sync: ubuntu-wsl2-docker-desktop-win-{{ os_version}}
+
+            .. code-block:: bash
+                :substitutions:
+
+                echo "deb [arch=amd64 signed-by=/etc/apt/keyrings/rocm.gpg] https://repo.radeon.com/rocm/apt/|rocm_version| {{ os_release }} main" \
+                    | sudo tee --append /etc/apt/sources.list.d/rocm.list
+                echo -e 'Package: *\nPin: release o=repo.radeon.com\nPin-Priority: 600' \
+                    | sudo tee /etc/apt/preferences.d/rocm-pin-600
+        {% endfor %}
+
+.. _ubuntu-wsl2-docker-desktop-win-install:
+
+Installing
+================================================
+
+Install override packages
+---------------------------------------------------------------------------
+
+Linux Docker containers running on Windows do not make use of ``amdgpu-dkms``,
+but instead use an alternative user-space ROCm Runtime (ROCr) relaying to the
+host driver.
+
+The following packages override the native packages.
+
+.. code-block:: bash
+
+    sudo apt install hsa-runtime-rocr4wsl-amdgpu rocminfo4wsl-amdgpu
+    sudo reboot
+
+Install ROCm packages
+---------------------------------------------------------------------------
+
+.. code-block:: bash
+
+    sudo apt install rocm
+
+Complete the :doc:`post-install`.
+
+.. _ubuntu-wsl2-docker-desktop-win-upgrade:
+
+Upgrading
+================================================
+
+To upgrade an existing ROCm installation to a newer version, follow the steps in
+:ref:`ubuntu-register-repo` and :ref:`ubuntu-install`. 
+
+.. note::
+
+    Upgrading the kernel driver may also upgrade the GPU firmware, which requires a
+    system reboot to take effect.
+
+.. _ubuntu-wsl2-docker-desktop-win-uninstall:
+
+Uninstalling
+================================================
+
+Uninstall specific meta packages
+---------------------------------------------------------------------------
+
+.. code-block:: bash
+    :substitutions:
+
+    # sudo apt autoremove <package-name>
+    # For example:
+    sudo apt autoremove rocm
+    # Or for version specific packages:
+    sudo apt autoremove rocm|rocm_version|
+
+Uninstall ROCm packages
+---------------------------------------------------------------------------
+
+.. code-block:: bash
+    :substitutions:
+
+    sudo apt autoremove rocm-core
+    # Or for version specific packages:
+    sudo apt autoremove rocm-core|rocm_version|
+
+Uninstall override packages
+---------------------------------------------------------------------------
+
+Although WSL2 and Docker Desktop for Windows installs don't need to uninstall
+the DKMS driver, the override packages were manually installed and won't be
+removed by uninstalling ``rocm-core``.
+
+.. code-block:: bash
+
+    sudo apt autoremove hsa-runtime-rocr4wsl-amdgpu rocminfo4wsl-amdgpu
+
+Remove ROCm and AMDGPU repositories
+---------------------------------------------------------------------------
+
+.. code-block:: bash
+
+    # Remove the repositories.
+    sudo rm /etc/apt/sources.list.d/rocm.list
+
+    # Clear the cache and clean the system.
+    sudo rm -rf /var/cache/apt/*
+    sudo apt-get clean all
+
+    # Restart the system.
+    sudo reboot

--- a/docs/how-to/native-install/ubuntu.rst
+++ b/docs/how-to/native-install/ubuntu.rst
@@ -46,7 +46,7 @@ Add the AMDGPU repository for the driver.
 
     .. tab-set::
         {% for (os_version, os_release) in config.html_context['ubuntu_version_numbers'] %}
-        .. tab-item:: Ubuntu {{ os_version }}
+        .. tab-item:: {{ os_version }}
             :sync: ubuntu-{{ os_version}}
 
             .. code-block:: bash
@@ -68,7 +68,7 @@ Add the ROCm repository.
 
     .. tab-set::
         {% for (os_version, os_release) in config.html_context['ubuntu_version_numbers'] %}
-        .. tab-item:: Ubuntu {{ os_version }}
+        .. tab-item:: {{ os_version }}
             :sync: ubuntu-{{ os_version}}
 
             .. code-block:: bash

--- a/docs/how-to/prerequisites.rst
+++ b/docs/how-to/prerequisites.rst
@@ -108,6 +108,11 @@ installation. Follow the instructions below based on your distributions.
             
                 {% endfor %}
 
+    .. tab-item:: Ubuntu (WSL2 / Docker Desktop for Windows)
+        :sync: ubuntu-wsl2-docker-desktop-win-tab
+
+        All packages are available in the default Ubuntu repositories, therefore no additional repositories need to be added.
+
 Kernel headers and development packages
 ================================================================
 
@@ -144,6 +149,11 @@ To install for the currently active kernel run the command corresponding to your
 
             sudo zypper install kernel-default-devel
 
+    .. tab-item:: Ubuntu (WSL2 / Docker Desktop for Windows)
+        :sync: ubuntu-wsl2-docker-desktop-win-tab
+
+        WSL2 and Docker for Windows don't make use of DKMS, instead they rely on an alternative ROCr (ROCm Runtime) binary relaying to the host driver.
+
 Setting permissions for groups
 ================================================================
 
@@ -172,3 +182,11 @@ the following commands:
     echo 'ADD_EXTRA_GROUPS=1' | sudo tee -a /etc/adduser.conf
     echo 'EXTRA_GROUPS=video' | sudo tee -a /etc/adduser.conf
     echo 'EXTRA_GROUPS=render' | sudo tee -a /etc/adduser.conf
+
+Host system requirements
+================================================================
+
+When installing ROCm in WSL2 or Docker Desktop for Windows containers, the host
+system must have the latest device drivers installed on the host system. To
+obtain the latest drivers for your system, visit
+`AMD Drivers and Support <https://www.amd.com/en/support>`_.

--- a/docs/reference/system-requirements.rst
+++ b/docs/reference/system-requirements.rst
@@ -87,8 +87,13 @@ AMD ROCm™ Software supports the following Linux distributions.
     "Ubuntu 22.04.2", "5.19", "✅"
     "Ubuntu 20.04.6", "5.15", "✅"
     "Ubuntu 20.04.5", "5.15", "✅"
+    "Ubuntu 22.04.3", "5.15.133.1-microsoft-standard-WSL2", "🚧 :sup:`3`"
+
+🚧: **Preview** - This configuration is under development and is released for preview purposes.
 
 :sup:`2` Preview support for HWE kernels
+
+:sup:`3` Preview support for device access in WSL2 and Docker Desktop for Windows.
 
 Virtualization support
 =============================================

--- a/docs/sphinx/_toc.yml.in
+++ b/docs/sphinx/_toc.yml.in
@@ -26,6 +26,8 @@ subtrees:
           title: Oracle Linux
         - file: how-to/native-install/sles
           title: SUSE Linux Enterprise
+        - file: how-to/native-install/ubuntu-wsl2-docker-desktop-win
+          title: WSL2 & Docker Desktop for Windows
         - file: how-to/native-install/post-install
           title: Post-Install instructions
         - file: how-to/native-install/package-manager-integration

--- a/docs/tutorial/quick-start.rst
+++ b/docs/tutorial/quick-start.rst
@@ -22,12 +22,14 @@ To start, choose your preferred install method and operating system:
         * :ref:`package-man-ubuntu`
         * :ref:`package-man-rhel`
         * :ref:`package-man-suse`
+        * :ref:`package-man-ol`
 
     .. grid-item-card:: :ref:`rocm-amdgpu-quick`
 
         * :ref:`amdgpu-ubuntu`
         * :ref:`amdgpu-rhel`
         * :ref:`amdgpu-suse`
+        * :ref:`amdgpu-ol`
 
 .. _rocm-package-man-quick:
 

--- a/docs/tutorial/quick-start.rst
+++ b/docs/tutorial/quick-start.rst
@@ -23,6 +23,7 @@ To start, choose your preferred install method and operating system:
         * :ref:`package-man-rhel`
         * :ref:`package-man-suse`
         * :ref:`package-man-ol`
+        * :ref:`package-man-ubuntu-wsl2-docker-desktop-win`
 
     .. grid-item-card:: :ref:`rocm-amdgpu-quick`
 
@@ -30,6 +31,7 @@ To start, choose your preferred install method and operating system:
         * :ref:`amdgpu-rhel`
         * :ref:`amdgpu-suse`
         * :ref:`amdgpu-ol`
+        * :ref:`amdgpu-ubuntu-wsl2-docker-desktop-win`
 
 .. _rocm-package-man-quick:
 
@@ -145,6 +147,28 @@ SUSE Linux Enterprise Server
                 echo "Please reboot system for all settings to take effect."
         {% endfor %}
 
+.. _package-man-ubuntu-wsl2-docker-desktop-win:
+
+Ubuntu (WSL2 / Docker for Windows)
+------------------------------------------------------------------------------------
+
+.. datatemplate:nodata::
+
+    .. tab-set::
+        {% for (os_version, os_release) in config.html_context['ubuntu_wsl2_docker_desktop_win_version_numbers'] %}
+        .. tab-item:: {{ os_version }}
+            :sync: ubuntu-wsl2-docker-desktop-win-{{ os_version}}
+
+            .. code-block:: bash
+                :substitutions:
+
+                wget https://repo.radeon.com/amdgpu-install/|amdgpu_version|/ubuntu/{{ os_release }}/amdgpu-install_|amdgpu_install_version|_all.deb
+                sudo apt install ./amdgpu-install_|amdgpu_install_version|_all.deb
+                sudo apt update
+                sudo apt install hsa-runtime-rocr4wsl-amdgpu rocminfo4wsl-amdgpu
+                sudo apt install rocm
+        {% endfor %}
+
 .. _rocm-amdgpu-quick:
 
 AMDGPU installer
@@ -226,4 +250,25 @@ SUSE Linux Enterprise Server
 
                 sudo zypper --no-gpg-checks install https://repo.radeon.com/amdgpu-install/|amdgpu_version|/sle/{{ os_version }}/amdgpu-install-|amdgpu_install_version|.noarch.rpm
                 sudo amdgpu-install --usecase=graphics,rocm
+        {% endfor %}
+
+.. _amdgpu-ubuntu-wsl2-docker-desktop-win:
+
+Ubuntu (WSL2 / Docker for Windows)
+------------------------------------------------------------------------------------
+
+.. datatemplate:nodata::
+
+    .. tab-set::
+        {% for (os_version, os_release) in config.html_context['ubuntu_wsl2_docker_desktop_win_version_numbers'] %}
+        .. tab-item:: {{ os_version }}
+            :sync: ubuntu-wsl2-docker-desktop-win-{{ os_version}}
+
+            .. code-block:: bash
+                :substitutions:
+
+                sudo apt update
+                wget https://repo.radeon.com/amdgpu-install/|amdgpu_version|/ubuntu/{{ os_release }}/amdgpu-install_|amdgpu_install_version|_all.deb
+                sudo apt install ./amdgpu-install_|amdgpu_install_version|_all.deb
+                sudo amdgpu-install --usecase=graphics,rocm,wsl
         {% endfor %}


### PR DESCRIPTION
fixes: ROCDOC-328

> This documentation requires considerable proof-reading from AMD-internal contributors.

AMD-internal documentation on WSL2 support is scarce, so the statements around Docker Desktop for Windows containers also having access GPU devices via the modified ROC Runtime is purely speculation. (It probably does work, given how Docker Desktop for Windows runs atop the very same kernel and infrastructure which WSL2 runs on. I would've verified it, but I don't have VPN access to hook APT up to Artifactory.)