### PR TITLE
Revert "Remove references to Oracle Linux"

### DIFF
--- a/docs/how-to/amdgpu-install.rst
+++ b/docs/how-to/amdgpu-install.rst
@@ -58,6 +58,23 @@ Red Hat Enterprise Linux
                 sudo yum install https://repo.radeon.com/amdgpu-install/|amdgpu_version|/rhel/{{ os_version }}/amdgpu-install-|amdgpu_install_version|.el{{ os_release }}.noarch.rpm
         {% endfor %}
 
+Oracle Linux
+--------------------------------------------------------------------
+
+.. datatemplate:nodata::
+
+    .. tab-set::
+        {% for (os_release, os_version) in config.html_context['ol_version_numbers'] %}
+        .. tab-item:: OL {{ os_version }}
+            :sync: ol-{{ os_version }} ol-{{ os_release }}
+
+            .. code-block:: bash
+                :substitutions:
+
+                sudo yum install https://repo.radeon.com/amdgpu-install/|amdgpu_version|/rhel/{{ os_version }}/amdgpu-install-|amdgpu_install_version|.el{{ os_release }}.noarch.rpm
+        {% endfor %}
+
+
 SUSE Linux Enterprise
 --------------------------------------------------------------------
 

--- a/docs/how-to/native-install/ol.rst
+++ b/docs/how-to/native-install/ol.rst
@@ -1,0 +1,85 @@
+.. meta::
+  :description: Oracle Linux native installation
+  :keywords: ROCm install, installation instructions, OL, Oracle Linux  native installation,
+    AMD, ROCm
+
+**********************************************************************************************
+Oracle Linux native installation
+**********************************************************************************************
+
+.. _ol-register-repo:
+
+Register repositories
+=====================================================
+
+Register kernel-mode driver
+----------------------------------------------------------------------------------------------------------
+
+.. datatemplate:nodata::
+
+    .. tab-set::
+        {% for (os_release, os_version) in config.html_context['ol_version_numbers'] %}
+        .. tab-item:: OL {{ os_version }}
+            :sync: ol-{{ os_version }} ol-{{ os_release }}
+
+            .. code-block:: bash
+                :substitutions:
+
+                sudo tee /etc/yum.repos.d/amdgpu.repo <<EOF
+                [amdgpu]
+                name=amdgpu
+                baseurl=https://repo.radeon.com/amdgpu/|rocm_version|/rhel/{{ os_version }}/main/x86_64/
+                enabled=1
+                priority=50
+                gpgcheck=1
+                gpgkey=https://repo.radeon.com/rocm/rocm.gpg.key
+                EOF
+                sudo yum clean all
+        {% endfor %}
+
+.. _ol-register-rocm:
+
+Register ROCm packages
+----------------------------------------------------------------------------------------------------------
+
+.. datatemplate:nodata::
+
+    .. tab-set::
+        {% for os_release in config.html_context['ol_release_version_numbers'] %}
+        .. tab-item:: OL {{ os_release }}
+            :sync: ol-{{ os_release }}
+
+            .. code-block:: bash
+                :substitutions:
+
+                sudo tee --append /etc/yum.repos.d/rocm.repo <<EOF
+                [ROCm-|rocm_version|]
+                name=ROCm|rocm_version|
+                baseurl=https://repo.radeon.com/rocm/rhel{{ os_release }}/|rocm_version|/main
+                enabled=1
+                priority=50
+                gpgcheck=1
+                gpgkey=https://repo.radeon.com/rocm/rocm.gpg.key
+                EOF
+
+                sudo yum clean all
+        {% endfor %}
+
+.. _ol-install:
+
+.. include:: install-rocm-template.rst
+
+Upgrade
+=====================================================
+
+To upgrade an existing ROCm installation to a newer version, follow the steps in
+:ref:`ol-register-repo` and :ref:`ol-install`. 
+
+.. note::
+
+    Upgrading the kernel driver may also upgrade the GPU firmware, which requires a
+    system reboot to take effect.
+
+.. _ol-uninstall:
+
+.. include:: uninstall-rocm-template.rst

--- a/docs/how-to/prerequisites.rst
+++ b/docs/how-to/prerequisites.rst
@@ -58,7 +58,7 @@ installation. Follow the instructions below based on your distributions.
 
         All packages are available in the default Ubuntu repositories, therefore no additional repositories need to be added.
 
-    .. tab-item:: Red Hat Enterprise Linux
+    .. tab-item:: Red Hat Enterprise Linux/Oracle Linux
         :sync: rhel-tab
 
         1. Add the EPEL repository.
@@ -128,7 +128,7 @@ To install for the currently active kernel run the command corresponding to your
 
             sudo apt install "linux-headers-$(uname -r)" "linux-modules-extra-$(uname -r)"
 
-    .. tab-item:: Red Hat Enterprise Linux
+    .. tab-item:: Red Hat Enterprise Linux/Oracle Linux
         :sync: rhel-tab
 
         .. code-block:: shell

--- a/docs/sphinx/_toc.yml.in
+++ b/docs/sphinx/_toc.yml.in
@@ -22,6 +22,8 @@ subtrees:
           title: Ubuntu
         - file: how-to/native-install/rhel
           title: RHEL
+        - file: how-to/native-install/ol
+          title: Oracle Linux
         - file: how-to/native-install/sles
           title: SLES
         - file: how-to/native-install/post-install

--- a/docs/tutorial/quick-start.rst
+++ b/docs/tutorial/quick-start.rst
@@ -88,6 +88,34 @@ Red Hat Enterprise Linux
                 echo "Please reboot system for all settings to take effect."
         {% endfor %}
 
+.. _package-man-ol:
+
+Oracle Linux
+------------------------------------------------------------------------------------
+
+.. datatemplate:nodata::
+
+    .. tab-set::
+        {% for (os_release, os_version) in config.html_context['ol_version_numbers'] %}
+        .. tab-item:: {{ os_version }}
+            :sync: ol-{{ os_version }} ol-{{ os_release }}
+
+            .. code-block:: bash
+                :substitutions:
+
+                wget https://dl.fedoraproject.org/pub/epel/epel-release-latest-{{ os_release }}.noarch.rpm
+                sudo rpm -ivh epel-release-latest-{{ os_release }}.noarch.rpm
+                sudo crb enable
+                sudo yum install kernel-headers kernel-devel
+                # See prerequisites. Adding current user to Video and Render groups
+                sudo usermod -a -G render,video $LOGNAME
+                sudo yum install https://repo.radeon.com/amdgpu-install/|amdgpu_version|/rhel/{{ os_version }}/amdgpu-install-|amdgpu_install_version|.el{{ os_release }}.noarch.rpm 
+                sudo yum clean all
+                sudo yum install amdgpu-dkms
+                sudo yum install rocm
+                echo "Please reboot system for all settings to take effect."
+        {% endfor %}
+
 .. _package-man-suse:
 
 SUSE Linux Enterprise Server
@@ -152,6 +180,25 @@ Red Hat Enterprise Linux
         {% for (os_release, os_version) in config.html_context['rhel_version_numbers'] %}
         .. tab-item:: {{ os_version }}
             :sync: rhel-{{ os_version }} rhel-{{ os_release }}
+
+            .. code-block:: bash
+                :substitutions:
+
+                sudo yum install https://repo.radeon.com/amdgpu-install/|amdgpu_version|/rhel/{{ os_version }}/amdgpu-install-|amdgpu_install_version|.el{{ os_release }}.noarch.rpm 
+                sudo amdgpu-install --usecase=graphics,rocm
+        {% endfor %}
+
+.. _amdgpu-ol:
+
+Oracle Linux
+------------------------------------------------------------------------------------
+
+.. datatemplate:nodata::
+
+    .. tab-set::
+        {% for (os_release, os_version) in config.html_context['ol_version_numbers'] %}
+        .. tab-item:: {{ os_version }}
+            :sync: ol-{{ os_version }} ol-{{ os_release }}
 
             .. code-block:: bash
                 :substitutions:


### PR DESCRIPTION
This reverts commit 76a9651eef2820652e8fd2901402dde77dd79cec.

RE:
Oracle support went into Develop, but it was backed out via this commit: https://github.com/ROCm/rocm-install-on-linux/commit/76a9651eef2820652e8fd2901402dde77dd79cec

it needs to be put back for ROCm 6.1 release, but we don't want the info to leak yet

