### PR TITLE
docs(pytorch-install.rst): Fix path typo when cloning PyTorch repo

### DIFF
--- a/docs/how-to/3rd-party/pytorch-install.rst
+++ b/docs/how-to/3rd-party/pytorch-install.rst
@@ -201,7 +201,7 @@ scripts to determine the configuration of the build environment.
 
        cd ~
        git clone https://github.com/pytorch/pytorch.git
-       cd /pytorch
+       cd pytorch
        git submodule update --init --recursive
 
 4. Set ROCm architecture (optional). The Docker image tag is ``rocm/pytorch:latest-base``.


### PR DESCRIPTION
Home directory (~) differs based on the current user

After going to the home directory via `cd ~` and cloning pytorch, it is unlikely the repo will be at the root directory `/pytorch`

Relative change directory `cd pytorch` is guaranteed correct