### PR TITLE
Merge Develop into docs/6.1.0

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -5,11 +5,11 @@
 # https://www.sphinx-doc.org/en/master/usage/configuration.html
 
 # ROCm version numbers
-rocm_version = '6.0.2'
-rocm_multi_versions = '6.0.2 6.0.0'
-rocm_directory_version = '6.0.2' # in 6.0 rocm was located in /opt/rocm-6.0.0
-amdgpu_version = '6.0.2' # directory in https://repo.radeon.com/rocm/apt/ and https://repo.radeon.com/amdgpu-install/
-amdgpu_install_version = '6.0.60002-1' # version in https://repo.radeon.com/amdgpu-install/6.0.2/ubuntu/jammy/
+rocm_version = '6.1'
+rocm_multi_versions = '6.1.0 6.0.2'
+rocm_directory_version = '6.1.0' # in 6.0 rocm was located in /opt/rocm-6.0.0
+amdgpu_version = '6.1' # directory in https://repo.radeon.com/rocm/apt/ and https://repo.radeon.com/amdgpu-install/
+amdgpu_install_version = '6.1.60100-1' # version in https://repo.radeon.com/amdgpu-install/6.0.2/ubuntu/jammy/
 
 latex_engine = "xelatex"
 latex_elements = {
@@ -24,8 +24,8 @@ latex_elements = {
 project = "ROCm installation on Linux"
 author = "Advanced Micro Devices, Inc."
 copyright = "Copyright (c) 2024 Advanced Micro Devices, Inc. All rights reserved."
-version = "6.0.2"
-release = "6.0.2"
+version = "6.1.0"
+release = "6.1.0"
 setting_all_article_info = True
 all_article_info_os = ["linux"]
 all_article_info_author = ""

--- a/docs/reference/system-requirements.rst
+++ b/docs/reference/system-requirements.rst
@@ -23,8 +23,8 @@ GPU is not listed on this table, it's not officially supported by AMD.
       :widths: 50, 25, 25, 10
       :header: "GPU", "Architecture", "LLVM target", "Support"
 
-      "AMD Instinct MI300X", "CDNA3", "gfx942", "✅"
-      "AMD Instinct MI300A", "CDNA3", "gfx942", "✅ :sup:`1`"
+      "AMD Instinct MI300X", "CDNA3", "gfx942", "✅ :sup:`1`"
+      "AMD Instinct MI300A", "CDNA3", "gfx942", "✅ :sup:`2`"
       "AMD Instinct MI250X", "CDNA2", "gfx90a", "✅"
       "AMD Instinct MI250", "CDNA2", "gfx90a", "✅"
       "AMD Instinct MI210", "CDNA2", "gfx90a", "✅"
@@ -62,7 +62,9 @@ ROCm product.
 
 ❌: **Unsupported** - This configuration is not enabled in our software distributions.
 
-:sup:`1` MI300A is currently not officially supported on RHEL 9.x. This will be added on a later date.
+:sup:`1` MI300X is only officially supported on Ubuntu 22.04.4.
+
+:sup:`2` MI300A is only officially supported on Ubuntu 22.04.4, RHEL 9.3, RHEL 8.9 and SLES 15 SP5.
 
 .. _supported_distributions:
 

--- a/docs/sphinx/requirements.in
+++ b/docs/sphinx/requirements.in
@@ -1,3 +1,3 @@
-rocm-docs-core==0.37.0
+rocm-docs-core==0.38.0
 Sphinx-Substitution-Extensions==2022.2.16
 sphinxcontrib.datatemplates==0.11.0

--- a/docs/sphinx/requirements.txt
+++ b/docs/sphinx/requirements.txt
@@ -102,7 +102,7 @@ requests==2.31.0
     # via
     #   pygithub
     #   sphinx
-rocm-docs-core==0.37.0
+rocm-docs-core==0.38.0
     # via -r requirements.in
 smmap==5.0.0
     # via gitdb


### PR DESCRIPTION
Squashed commit of the following:

    Merge pull request #118 from ROCm/dependabot/pip/docs/sphinx/rocm-docs-core-0.38.0

    build(deps): Bump rocm-docs-core from 0.37.0 to 0.38.0 in /docs/sphinx

    update MI300A OS support (#116)

    build(deps): Bump rocm-docs-core from 0.37.0 to 0.38.0 in /docs/sphinx

