### PR TITLE
Fix table syntax error preventing table from rendering

### DIFF
--- a/docs/how-to/native-install/package-manager-integration.rst
+++ b/docs/how-to/native-install/package-manager-integration.rst
@@ -81,7 +81,7 @@ All meta-packages are a combination of required packages and libraries.
 .. csv-table::
   :widths: 30, 70
   :delim: ;
-  :header: "Package", "Description"
+  :header: Package; Description
 
     ``rocm``; All ROCm core packages, tools, and libraries.
     ``rocm-language-runtime``; The ROCm runtime.


### PR DESCRIPTION
Issue: The **Components of ROCm programming models** table is missing from the docs portal on docs/6.1.1.

This PR fixes the `:header:` option in the ROCm packages table to use the same format as the main data.

The issue is due to an update to the reStructuredText spec itself in April (https://docutils.sourceforge.io/RELEASE-NOTES.html#release-0-21-2024-04-09)
>Use the same CSV format for the :header: option and the main data of the csv-table directive.

Doesn't affect docs/6.1.0 and earlier.