### PR TITLE
docs/6.1.0: Fix table syntax error preventing table from rendering (#162)

### DIFF
--- a/docs/how-to/native-install/package-manager-integration.rst
+++ b/docs/how-to/native-install/package-manager-integration.rst
@@ -81,7 +81,7 @@ All meta-packages are a combination of required packages and libraries.
 .. csv-table::
   :widths: 30, 70
   :delim: ;
-  :header: "Package", "Description"
+  :header: Package; Description
 
     ``rocm``; All ROCm core packages, tools, and libraries.
     ``rocm-language-runtime``; The ROCm runtime.


### PR DESCRIPTION
@samjwu The issue occurs (#162) when the `docutils` dep is > `0.21`. I think if you don't plan on updating requirements in docs pre-6.1.1 branches, we should not add this to 6.1.0.
![image](https://github.com/ROCm/rocm-install-on-linux/assets/115042610/465f69a9-e373-4b70-8c2c-f0ad4cf4db22)
