### PR TITLE
Remove amdgpu installation from quick start

### DIFF
--- a/docs/sphinx/_toc.yml.in
+++ b/docs/sphinx/_toc.yml.in
@@ -5,7 +5,7 @@ root: index
 subtrees:
 - entries:
     - file: tutorial/quick-start
-      title: Quick start install guide
+      title: Quick start installation
     - file: how-to/prerequisites
       title: Prerequisites
     - file: tutorial/install-overview
@@ -40,9 +40,9 @@ subtrees:
   - file: how-to/3rd-party/jax-install
     title: JAX
   - file: how-to/3rd-party/magma-install
-    title: Magma
+    title: MAGMA
     
-- caption: How-to
+- caption: How to
   entries:
   - file: how-to/docker
     title: Run Docker containers

--- a/docs/tutorial/quick-start.rst
+++ b/docs/tutorial/quick-start.rst
@@ -33,6 +33,7 @@ For more in-depth installation instructions, refer to :ref:`rocm-install-overvie
                         sudo usermod -a -G render,video $LOGNAME # Add the current user to the render and video groups
                         wget https://repo.radeon.com/amdgpu-install/|amdgpu_version|/ubuntu/{{ os_release }}/amdgpu-install_|amdgpu_install_version|_all.deb
                         sudo apt install ./amdgpu-install_|amdgpu_install_version|_all.deb
+                        sudo apt update
                         sudo apt install amdgpu-dkms rocm
                 {% endfor %}
 
@@ -86,4 +87,4 @@ For more in-depth installation instructions, refer to :ref:`rocm-install-overvie
 
    Reboot your system for all settings to take effect.
 
-If you encounter install issues, refer to :doc:`Troubleshooting <../how-to/native-install/install-faq>`.
+If you encounter issues with your installation, refer to :doc:`Troubleshooting <../how-to/native-install/install-faq>`.

--- a/docs/tutorial/quick-start.rst
+++ b/docs/tutorial/quick-start.rst
@@ -5,12 +5,10 @@
 .. _rocm-install-quick:
 
 *************************************************************
-ROCm quick start install guide for Linux
+ROCm quick start installation guide for Linux
 *************************************************************
 
-The following are steps to install ROCm on Linux via your distribution's native package manager. To get
-started with ROCm on Linux, select your operating system and version, then run the provided commands in your
-terminal.
+This topic provides basic installation instructions for ROCm on Linux using your distribution’s native package manager. Review your required installation instructions by selecting your operating system and version, and then run the provided commands in your terminal.
 
 For more in-depth installation instructions, refer to :ref:`rocm-install-overview`.
 
@@ -85,6 +83,6 @@ For more in-depth installation instructions, refer to :ref:`rocm-install-overvie
 
 .. important::
 
-   Reboot your system for all settings to take effect.
+   To apply all settings, reboot your system.
 
-If you encounter issues with your installation, refer to :doc:`Troubleshooting <../how-to/native-install/install-faq>`.
+If you have issues with your installation, see :doc:`Troubleshooting <../how-to/native-install/install-faq>`.

--- a/docs/tutorial/quick-start.rst
+++ b/docs/tutorial/quick-start.rst
@@ -8,9 +8,11 @@
 ROCm quick start install guide for Linux
 *************************************************************
 
-For a quick summary on installing ROCm on Linux, choose your preferred operating
-system and install method and follow the steps listed in the table. If you want
-more in-depth installation instructions, refer to :ref:`rocm-install-overview`.
+The following are steps to install ROCm on Linux via your distribution's native package manager. To get
+started with ROCm on Linux, select your operating system and version, then run the provided commands in your
+terminal.
+
+For more in-depth installation instructions, refer to :ref:`rocm-install-overview`.
 
 .. datatemplate:nodata::
 
@@ -23,35 +25,17 @@ more in-depth installation instructions, refer to :ref:`rocm-install-overview`.
                 {% for (os_version, os_release) in config.html_context['ubuntu_version_numbers'] %}
                 .. tab-item:: {{ os_version }}
 
-                    .. tab-set::
+                    .. code-block:: bash
+                        :substitutions:
 
-                        .. tab-item:: Native package manager
-                            :sync: native-package-manager
-
-                            .. code-block:: bash
-                                :substitutions:
-
-                                sudo apt install "linux-headers-$(uname -r)" "linux-modules-extra-$(uname -r)"
-                                sudo usermod -a -G render,video $LOGNAME # Adding current user to Video, Render groups. See prerequisites.
-                                wget https://repo.radeon.com/amdgpu-install/|amdgpu_version|/ubuntu/{{ os_release }}/amdgpu-install_|amdgpu_install_version|_all.deb
-                                sudo apt install ./amdgpu-install_|amdgpu_install_version|_all.deb
-                                sudo apt update
-                                sudo apt install amdgpu-dkms
-                                sudo apt install rocm
-                                echo "Please reboot system for all settings to take effect."
-
-                        .. tab-item:: AMDGPU installer
-                            :sync: amdgpu-installer
-
-                            .. code-block:: bash
-                                :substitutions:
-
-                                sudo apt install "linux-headers-$(uname -r)" "linux-modules-extra-$(uname -r)"
-                                sudo usermod -a -G render,video $LOGNAME # Adding current user to Video, Render groups. See prerequisites.
-                                sudo apt update
-                                wget https://repo.radeon.com/amdgpu-install/|amdgpu_version|/ubuntu/{{ os_release }}/amdgpu-install_|amdgpu_install_version|_all.deb
-                                sudo apt install ./amdgpu-install_|amdgpu_install_version|_all.deb
-                                sudo amdgpu-install --usecase=graphics,rocm
+                        sudo apt install "linux-headers-$(uname -r)" "linux-modules-extra-$(uname -r)"
+                        sudo usermod -a -G render,video $LOGNAME # Adding current user to Video, Render groups. See prerequisites.
+                        wget https://repo.radeon.com/amdgpu-install/|amdgpu_version|/ubuntu/{{ os_release }}/amdgpu-install_|amdgpu_install_version|_all.deb
+                        sudo apt install ./amdgpu-install_|amdgpu_install_version|_all.deb
+                        sudo apt update
+                        sudo apt install amdgpu-dkms
+                        sudo apt install rocm
+                        echo "Please reboot system for all settings to take effect."
                 {% endfor %}
 
         .. tab-item:: Red Hat Enterprise Linux
@@ -62,40 +46,20 @@ more in-depth installation instructions, refer to :ref:`rocm-install-overview`.
                 {% set os_major, _  = os_version.split('.') %}
                 .. tab-item:: {{ os_version }}
 
-                    .. tab-set::
+                    .. code-block:: bash
+                        :substitutions:
 
-                        .. tab-item:: Native package manager
-                            :sync: native-package-manager
-
-                            .. code-block:: bash
-                                :substitutions:
-
-                                wget https://dl.fedoraproject.org/pub/epel/epel-release-latest-{{ os_major }}.noarch.rpm
-                                sudo rpm -ivh epel-release-latest-{{ os_major }}.noarch.rpm
-                                sudo dnf install dnf-plugin-config-manager
-                                sudo crb enable
-                                sudo yum install kernel-headers kernel-devel
-                                sudo usermod -a -G render,video $LOGNAME # Adding current user to Video, Render groups. See prerequisites.
-                                sudo yum install https://repo.radeon.com/amdgpu-install/|amdgpu_version|/rhel/{{ os_version }}/amdgpu-install-|amdgpu_install_version|.el{{ os_major }}.noarch.rpm
-                                sudo yum clean all
-                                sudo yum install amdgpu-dkms
-                                sudo yum install rocm
-                                echo "Please reboot system for all settings to take effect."
-
-                        .. tab-item:: AMDGPU installer
-                            :sync: amdgpu-installer
-
-                            .. code-block:: bash
-                                :substitutions:
-
-                                wget https://dl.fedoraproject.org/pub/epel/epel-release-latest-{{ os_major }}.noarch.rpm
-                                sudo rpm -ivh epel-release-latest-{{ os_major }}.noarch.rpm
-                                sudo dnf install dnf-plugin-config-manager
-                                sudo crb enable
-                                sudo yum install kernel-headers kernel-devel
-                                sudo usermod -a -G render,video $LOGNAME # Adding current user to Video, Render groups. See prerequisites.
-                                sudo yum install https://repo.radeon.com/amdgpu-install/|amdgpu_version|/rhel/{{ os_version }}/amdgpu-install-|amdgpu_install_version|.el{{ os_major }}.noarch.rpm
-                                sudo amdgpu-install --usecase=graphics,rocm
+                        wget https://dl.fedoraproject.org/pub/epel/epel-release-latest-{{ os_major }}.noarch.rpm
+                        sudo rpm -ivh epel-release-latest-{{ os_major }}.noarch.rpm
+                        sudo dnf install dnf-plugin-config-manager
+                        sudo crb enable
+                        sudo yum install kernel-headers kernel-devel
+                        sudo usermod -a -G render,video $LOGNAME # Adding current user to Video, Render groups. See prerequisites.
+                        sudo yum install https://repo.radeon.com/amdgpu-install/|amdgpu_version|/rhel/{{ os_version }}/amdgpu-install-|amdgpu_install_version|.el{{ os_major }}.noarch.rpm
+                        sudo yum clean all
+                        sudo yum install amdgpu-dkms
+                        sudo yum install rocm
+                        echo "Please reboot system for all settings to take effect."
                 {% endfor %}
 
 
@@ -106,42 +70,20 @@ more in-depth installation instructions, refer to :ref:`rocm-install-overview`.
                 {% for os_version in config.html_context['sles_version_numbers'] %}
                 .. tab-item:: {{ os_version }}
 
-                    .. tab-set::
-
-                        .. tab-item:: Native package manager
-                            :sync: native-package-manager
-
-                            .. code-block:: bash
-                                :substitutions:
+                    .. code-block:: bash
+                        :substitutions:
 
                 {% if os_version == "15.4" %}
-                                # Installing Perl module from SLES 15.5, as it was removed from 15.4
-                                sudo zypper addrepo https://download.opensuse.org/repositories/devel:/languages:/perl/15.5/devel:languages:perl.repo
+                        # Installing Perl module from SLES 15.5, as it was removed from 15.4
+                        sudo zypper addrepo https://download.opensuse.org/repositories/devel:/languages:/perl/15.5/devel:languages:perl.repo
                 {% else %}
-                                sudo zypper addrepo https://download.opensuse.org/repositories/devel:languages:perl/{{ os_version}}/devel:languages:perl.repo
+                        sudo zypper addrepo https://download.opensuse.org/repositories/devel:languages:perl/{{ os_version}}/devel:languages:perl.repo
                 {% endif %}
-                                sudo zypper install kernel-default-devel
-                                sudo usermod -a -G render,video $LOGNAME # Adding current user to Video, Render groups. See prerequisites.
-                                sudo zypper --no-gpg-checks install https://repo.radeon.com/amdgpu-install/|amdgpu_version|/sle/{{ os_version }}/amdgpu-install-|amdgpu_install_version|.noarch.rpm
-                                sudo zypper refresh
-                                sudo zypper install amdgpu-dkms
-                                sudo zypper install rocm
-                                echo "Please reboot system for all settings to take effect."
-
-                        .. tab-item:: AMDGPU installer
-                            :sync: amdgpu-installer
-
-                            .. code-block:: bash
-                                :substitutions:
-
-                {% if os_version == "15.4" %}
-                                # Installing Perl module from SLES 15.5, as it was removed from 15.4
-                                sudo zypper addrepo https://download.opensuse.org/repositories/devel:/languages:/perl/15.5/devel:languages:perl.repo
-                {% else %}
-                                sudo zypper addrepo https://download.opensuse.org/repositories/devel:languages:perl/{{ os_version}}/devel:languages:perl.repo
-                {% endif %}
-                                sudo zypper install kernel-default-devel
-                                sudo usermod -a -G render,video $LOGNAME # Adding current user to Video, Render groups. See prerequisites.
-                                sudo zypper --no-gpg-checks install https://repo.radeon.com/amdgpu-install/|amdgpu_version|/sle/{{ os_version }}/amdgpu-install-|amdgpu_install_version|.noarch.rpm
-                                sudo amdgpu-install --usecase=graphics,rocm
+                        sudo zypper install kernel-default-devel
+                        sudo usermod -a -G render,video $LOGNAME # Adding current user to Video, Render groups. See prerequisites.
+                        sudo zypper --no-gpg-checks install https://repo.radeon.com/amdgpu-install/|amdgpu_version|/sle/{{ os_version }}/amdgpu-install-|amdgpu_install_version|.noarch.rpm
+                        sudo zypper refresh
+                        sudo zypper install amdgpu-dkms
+                        sudo zypper install rocm
+                        echo "Please reboot system for all settings to take effect."
                 {% endfor %}

--- a/docs/tutorial/quick-start.rst
+++ b/docs/tutorial/quick-start.rst
@@ -81,7 +81,7 @@ For more in-depth installation instructions, refer to :ref:`rocm-install-overvie
                         sudo zypper install amdgpu-dkms rocm
                 {% endfor %}
 
-.. important::
+.. note::
 
    To apply all settings, reboot your system.
 

--- a/docs/tutorial/quick-start.rst
+++ b/docs/tutorial/quick-start.rst
@@ -28,14 +28,13 @@ For more in-depth installation instructions, refer to :ref:`rocm-install-overvie
                     .. code-block:: bash
                         :substitutions:
 
+                        sudo apt update
                         sudo apt install "linux-headers-$(uname -r)" "linux-modules-extra-$(uname -r)"
-                        sudo usermod -a -G render,video $LOGNAME # Adding current user to Video, Render groups. See prerequisites.
+                        # Add the current user to the render and video groups (see prerequisites).
+                        sudo usermod -a -G render,video $LOGNAME
                         wget https://repo.radeon.com/amdgpu-install/|amdgpu_version|/ubuntu/{{ os_release }}/amdgpu-install_|amdgpu_install_version|_all.deb
                         sudo apt install ./amdgpu-install_|amdgpu_install_version|_all.deb
-                        sudo apt update
-                        sudo apt install amdgpu-dkms
-                        sudo apt install rocm
-                        echo "Please reboot system for all settings to take effect."
+                        sudo apt install amdgpu-dkms rocm
                 {% endfor %}
 
         .. tab-item:: Red Hat Enterprise Linux
@@ -54,12 +53,11 @@ For more in-depth installation instructions, refer to :ref:`rocm-install-overvie
                         sudo dnf install dnf-plugin-config-manager
                         sudo crb enable
                         sudo yum install kernel-headers kernel-devel
-                        sudo usermod -a -G render,video $LOGNAME # Adding current user to Video, Render groups. See prerequisites.
+                        # Add the current user to the render and video groups (see prerequisites).
+                        sudo usermod -a -G render,video $LOGNAME
                         sudo yum install https://repo.radeon.com/amdgpu-install/|amdgpu_version|/rhel/{{ os_version }}/amdgpu-install-|amdgpu_install_version|.el{{ os_major }}.noarch.rpm
                         sudo yum clean all
-                        sudo yum install amdgpu-dkms
-                        sudo yum install rocm
-                        echo "Please reboot system for all settings to take effect."
+                        sudo yum install amdgpu-dkms rocm
                 {% endfor %}
 
 
@@ -80,10 +78,13 @@ For more in-depth installation instructions, refer to :ref:`rocm-install-overvie
                         sudo zypper addrepo https://download.opensuse.org/repositories/devel:languages:perl/{{ os_version}}/devel:languages:perl.repo
                 {% endif %}
                         sudo zypper install kernel-default-devel
-                        sudo usermod -a -G render,video $LOGNAME # Adding current user to Video, Render groups. See prerequisites.
+                        # Add the current user to the render and video groups (see prerequisites).
+                        sudo usermod -a -G render,video $LOGNAME
                         sudo zypper --no-gpg-checks install https://repo.radeon.com/amdgpu-install/|amdgpu_version|/sle/{{ os_version }}/amdgpu-install-|amdgpu_install_version|.noarch.rpm
                         sudo zypper refresh
-                        sudo zypper install amdgpu-dkms
-                        sudo zypper install rocm
-                        echo "Please reboot system for all settings to take effect."
+                        sudo zypper install amdgpu-dkms rocm
                 {% endfor %}
+
+.. important::
+
+   Reboot your system for all settings to take effect.

--- a/docs/tutorial/quick-start.rst
+++ b/docs/tutorial/quick-start.rst
@@ -30,8 +30,7 @@ For more in-depth installation instructions, refer to :ref:`rocm-install-overvie
 
                         sudo apt update
                         sudo apt install "linux-headers-$(uname -r)" "linux-modules-extra-$(uname -r)"
-                        # Add the current user to the render and video groups (see prerequisites).
-                        sudo usermod -a -G render,video $LOGNAME
+                        sudo usermod -a -G render,video $LOGNAME # Add the current user to the render and video groups
                         wget https://repo.radeon.com/amdgpu-install/|amdgpu_version|/ubuntu/{{ os_release }}/amdgpu-install_|amdgpu_install_version|_all.deb
                         sudo apt install ./amdgpu-install_|amdgpu_install_version|_all.deb
                         sudo apt install amdgpu-dkms rocm
@@ -53,8 +52,7 @@ For more in-depth installation instructions, refer to :ref:`rocm-install-overvie
                         sudo dnf install dnf-plugin-config-manager
                         sudo crb enable
                         sudo yum install kernel-headers kernel-devel
-                        # Add the current user to the render and video groups (see prerequisites).
-                        sudo usermod -a -G render,video $LOGNAME
+                        sudo usermod -a -G render,video $LOGNAME # Add the current user to the render and video groups
                         sudo yum install https://repo.radeon.com/amdgpu-install/|amdgpu_version|/rhel/{{ os_version }}/amdgpu-install-|amdgpu_install_version|.el{{ os_major }}.noarch.rpm
                         sudo yum clean all
                         sudo yum install amdgpu-dkms rocm
@@ -78,8 +76,7 @@ For more in-depth installation instructions, refer to :ref:`rocm-install-overvie
                         sudo zypper addrepo https://download.opensuse.org/repositories/devel:languages:perl/{{ os_version}}/devel:languages:perl.repo
                 {% endif %}
                         sudo zypper install kernel-default-devel
-                        # Add the current user to the render and video groups (see prerequisites).
-                        sudo usermod -a -G render,video $LOGNAME
+                        sudo usermod -a -G render,video $LOGNAME # Add the current user to the render and video groups
                         sudo zypper --no-gpg-checks install https://repo.radeon.com/amdgpu-install/|amdgpu_version|/sle/{{ os_version }}/amdgpu-install-|amdgpu_install_version|.noarch.rpm
                         sudo zypper refresh
                         sudo zypper install amdgpu-dkms rocm


### PR DESCRIPTION
This PR removes ROCm installation instructions using the amdgpu installler from the Quick start page