### PR TITLE
docs/6.1.0: Fix table syntax error preventing table from rendering (#162)

### DIFF
--- a/docs/how-to/native-install/package-manager-integration.rst
+++ b/docs/how-to/native-install/package-manager-integration.rst
@@ -81,7 +81,7 @@ All meta-packages are a combination of required packages and libraries.
 .. csv-table::
   :widths: 30, 70
   :delim: ;
-  :header: "Package", "Description"
+  :header: Package; Description
 
     ``rocm``; All ROCm core packages, tools, and libraries.
     ``rocm-language-runtime``; The ROCm runtime.


### PR DESCRIPTION
Accidentally closed in https://github.com/ROCm/rocm-install-on-linux/pull/164.
