### PR TITLE
Add text for registering and help with dockers, before install (#176)

### DIFF
--- a/docs/how-to/native-install/install-faq.rst
+++ b/docs/how-to/native-install/install-faq.rst
@@ -91,3 +91,45 @@ The returned information should reflect the addition of ``iommu``:
 
 Refer to `RCCL Issue #1129 <https://github.com/ROCm/rccl/issues/1129>`_ for more information. 
 
+.. _troubleshooting-install-missing-packages-for-dockers:
+
+Issue #6: Additional packages for Docker installations
+========================================================
+
+Docker images often come with minimal installations, meaning some essential packages might be missing. When installing ROCm within a Docker container, you might need to install additional packages for a successful ROCm installation. Use the following commands to install the prerequisite packages.
+
+.. tab-set::
+
+  .. tab-item:: Ubuntu
+
+    .. code-block:: shell
+
+      apt update
+      apt install sudo wget
+
+
+  .. tab-item:: RHEL
+
+    .. code-block:: shell
+
+      dnf install sudo wget
+      subscription-manager register --username <username> --password <password>
+      subscription-manager attach --auto
+      subscription-manager repos --enable codeready-builder-for-rhel-9-x86_64-rpms
+
+
+  .. tab-item:: SLES
+
+    .. code-block:: shell
+
+      zypper install sudo wget SUSEConnect
+      SUSEConnect -r <REGCODE>
+      SUSEConnect -p sle-module-desktop-application/15.4/x86_64
+      SUSEConnect -p sle-module-development-tools/15.4/x86_64
+      SUSEConnect -p PackageHub/15.4/x86_64
+
+
+After installing these packages and :ref:`registering using your license for Enterprise Linux <register-enterprise-linux>` (if applicable), install ROCm following the :doc:`Quick start installation guide <../../tutorial/quick-start>` in your Docker container.
+
+
+

--- a/docs/how-to/prerequisites.rst
+++ b/docs/how-to/prerequisites.rst
@@ -44,20 +44,64 @@ Before installing ROCm, complete the following prerequisites.
 
    * Confirm that your kernel version matches the system requirements, as listed in :ref:`supported_distributions`.
 
+.. _register-enterprise-linux:
+
+Register your Enterprise Linux
+==========================================================
+
+If you're using Red Hat Enterprise Linux (RHEL) or SUSE Linux Enterprise Server (SLES), register
+your operating system to ensure you're able to download and install packages.
+
+.. tab-set::
+
+  .. tab-item:: Ubuntu
+        :sync: ubuntu-tab
+
+        There is no registration required for Ubuntu.
+
+  .. tab-item:: Red Hat Enterprise Linux
+        :sync: rhel-tab
+
+        Typically you can register by following the step-by-step user interface.
+        If you need to register by command line, use the following commands:
+
+        .. code-block:: shell
+
+            subscription-manager register --username <username> --password <password>
+            subscription-manager attach --auto
+            subscription-manager repos --enable codeready-builder-for-rhel-9-x86_64-rpms
+
+        More details about `registering for RHEL <https://access.redhat.com/solutions/253273>`_
+
+  .. tab-item:: SUSE Linux Enterprise Server
+        :sync: sle-tab
+
+        Typically you can register by following the step-by-step user interface.
+        If you need to register by command line, use the following commands:
+
+        .. code-block:: shell
+
+            SUSEConnect -r <REGCODE>
+            SUSEConnect -p sle-module-desktop-application/15.4/x86_64
+            SUSEConnect -p sle-module-development-tools/15.4/x86_64
+            SUSEConnect -p PackageHub/15.4/x86_64
+
+        More details about `registering for SLES <https://www.suse.com/support/kb/doc/?id=000018564>`_
+
+
 Additional package repositories
 ==========================================================
 
-On some distributions the ROCm packages depend on packages outside the default package
-repositories. These extra repositories need to be enabled before installation. Use the following
-instructions for your distribution.
+For some distributions, the ROCm installation packages depend on packages that aren't included in the default package
+repositories. These external repositories need to be sourced before installation. Use the following
+instructions specific to your distribution to add the necessary repositories.
 
 .. tab-set::
 
     .. tab-item:: Ubuntu
         :sync: ubuntu-tab
 
-        All packages are available in the default Ubuntu repositories, so you don't need to add additional
-        repositories.
+        All ROCm installation packages are available in the default Ubuntu repositories.
 
     .. tab-item:: Red Hat Enterprise Linux
         :sync: rhel-tab

--- a/docs/tutorial/quick-start.rst
+++ b/docs/tutorial/quick-start.rst
@@ -4,9 +4,9 @@
 
 .. _rocm-install-quick:
 
-*************************************************************
-ROCm quick start installation guide for Linux
-*************************************************************
+******************************
+Quick start installation guide
+******************************
 
 This topic provides basic installation instructions for ROCm on Linux using your distribution’s native package manager. Review your required installation instructions by selecting your operating system and version, and then run the provided commands in your terminal.
 
@@ -23,16 +23,16 @@ For more in-depth installation instructions, refer to :ref:`rocm-install-overvie
                 {% for (os_version, os_release) in config.html_context['ubuntu_version_numbers'] %}
                 .. tab-item:: {{ os_version }}
 
-                    .. code-block:: bash
-                        :substitutions:
+                   .. code-block:: bash
+                       :substitutions:
 
-                        sudo apt update
-                        sudo apt install "linux-headers-$(uname -r)" "linux-modules-extra-$(uname -r)"
-                        sudo usermod -a -G render,video $LOGNAME # Add the current user to the render and video groups
-                        wget https://repo.radeon.com/amdgpu-install/|amdgpu_version|/ubuntu/{{ os_release }}/amdgpu-install_|amdgpu_install_version|_all.deb
-                        sudo apt install ./amdgpu-install_|amdgpu_install_version|_all.deb
-                        sudo apt update
-                        sudo apt install amdgpu-dkms rocm
+                       sudo apt update
+                       sudo apt install "linux-headers-$(uname -r)" "linux-modules-extra-$(uname -r)"
+                       sudo usermod -a -G render,video $LOGNAME # Add the current user to the render and video groups
+                       wget https://repo.radeon.com/amdgpu-install/|amdgpu_version|/ubuntu/{{ os_release }}/amdgpu-install_|amdgpu_install_version|_all.deb
+                       sudo apt install ./amdgpu-install_|amdgpu_install_version|_all.deb
+                       sudo apt update
+                       sudo apt install amdgpu-dkms rocm
                 {% endfor %}
 
         .. tab-item:: Red Hat Enterprise Linux
@@ -42,6 +42,8 @@ For more in-depth installation instructions, refer to :ref:`rocm-install-overvie
                 {% for os_version in config.html_context['rhel_version_numbers'] %}
                 {% set os_major, _  = os_version.split('.') %}
                 .. tab-item:: {{ os_version }}
+
+                   Before installing ROCm on RHEL, :ref:`register your Enterprise Linux <register-enterprise-linux>`.
 
                    .. code-block:: bash
                        :substitutions:
@@ -63,7 +65,6 @@ For more in-depth installation instructions, refer to :ref:`rocm-install-overvie
                 {% endif %}
                 {% endfor %}
 
-
         .. tab-item:: SUSE Linux Enterprise Server
 
             .. tab-set::
@@ -71,24 +72,26 @@ For more in-depth installation instructions, refer to :ref:`rocm-install-overvie
                 {% for os_version in config.html_context['sles_version_numbers'] %}
                 .. tab-item:: {{ os_version }}
 
-                    .. code-block:: bash
-                        :substitutions:
+                   Before installing ROCm on SLES, :ref:`register your Enterprise Linux <register-enterprise-linux>`.
+
+                   .. code-block:: bash
+                       :substitutions:
 
                 {% if os_version == "15.4" %}
-                        # Installing Perl module from SLES 15.5, as it was removed from 15.4
-                        sudo zypper addrepo https://download.opensuse.org/repositories/devel:/languages:/perl/15.5/devel:languages:perl.repo
+                       # Installing Perl module from SLES 15.5, as it was removed from 15.4
+                       sudo zypper addrepo https://download.opensuse.org/repositories/devel:/languages:/perl/15.5/devel:languages:perl.repo
                 {% else %}
-                        sudo zypper addrepo https://download.opensuse.org/repositories/devel:languages:perl/{{ os_version}}/devel:languages:perl.repo
+                       sudo zypper addrepo https://download.opensuse.org/repositories/devel:languages:perl/{{ os_version}}/devel:languages:perl.repo
                 {% endif %}
-                        sudo zypper install kernel-default-devel
-                        sudo usermod -a -G render,video $LOGNAME # Add the current user to the render and video groups
-                        sudo zypper --no-gpg-checks install https://repo.radeon.com/amdgpu-install/|amdgpu_version|/sle/{{ os_version }}/amdgpu-install-|amdgpu_install_version|.noarch.rpm
-                        sudo zypper refresh
-                        sudo zypper install amdgpu-dkms rocm
+                       sudo zypper install kernel-default-devel
+                       sudo usermod -a -G render,video $LOGNAME # Add the current user to the render and video groups
+                       sudo zypper --no-gpg-checks install https://repo.radeon.com/amdgpu-install/|amdgpu_version|/sle/{{ os_version }}/amdgpu-install-|amdgpu_install_version|.noarch.rpm
+                       sudo zypper refresh
+                       sudo zypper install amdgpu-dkms rocm
                 {% endfor %}
 
 .. note::
 
-   To apply all settings, reboot your system.
+    To apply all settings, reboot your system.
 
-If you have issues with your installation, see :doc:`Troubleshooting <../how-to/native-install/install-faq>`.
+After completing the installation, review the :doc:`../how-to/native-install/post-install`. If you have issues with your installation, see :doc:`Troubleshooting <../how-to/native-install/install-faq>`.


### PR DESCRIPTION
* add text for registering and help with dockers

* Add @lpaoletti feedback from #168

post-install blurb

* move FAQ text into prerequisite steps

* fix tabs

* Move note to register enterprise linux distro

Remove sentence in top section

* Update refs to register-enterprise-linux

* Update some words in Prereqs

* registering should be in prerequisites, but dockers should only be in FAQ

* only provide prerequisite link on registering

* move the reboot message back out of tabs

* RHEL alignment seems off

* Apply suggestions from code review



* Fix whitespace & formatting

---------