### PR TITLE
Sudo update fix for Ubuntu install instructions in branch 6.0.0

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -59,6 +59,7 @@ external_projects_current_project = "rocm"
 rst_prolog = f"""
 .. |rocm_version| replace:: {rocm_version}
 .. |amdgpu_version| replace:: {amdgpu_version}
+.. |rocm_directory_version| replace:: {rocm_directory_version}
 .. |amdgpu_install_version| replace:: {amdgpu_install_version}
 """
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -6,7 +6,8 @@
 
 # ROCm version numbers
 rocm_version = '6.0'
-amdgpu_version = '6.0' # directory in # directory in https://repo.radeon.com/rocm/apt/https://repo.radeon.com/amdgpu-install/
+rocm_directory_version = '6.0.0' # in 6.0 rcom was located in /opt/rocm-6.0.0
+amdgpu_version = '6.0' # directory in https://repo.radeon.com/rocm/apt/ and https://repo.radeon.com/amdgpu-install/
 amdgpu_install_version = '6.0.60000-1' # version in https://repo.radeon.com/amdgpu-install/5.7.1/ubuntu/focal/
 
 latex_engine = "xelatex"

--- a/docs/how-to/native-install/post-install.rst
+++ b/docs/how-to/native-install/post-install.rst
@@ -25,7 +25,7 @@ Post-installation instructions
     .. code-block:: bash
         :substitutions:
 
-        export PATH=$PATH:/opt/rocm-|rocm_version|/bin
+        export PATH=$PATH:/opt/rocm-|rocm_directory_version|/bin
 
 3. Verify kernel-mode driver installation.
 
@@ -38,8 +38,8 @@ Post-installation instructions
     .. code-block:: bash
         :substitutions:
 
-        /opt/rocm-|rocm_version|/bin/rocminfo
-        /opt/rocm-|rocm_version|/bin/clinfo
+        /opt/rocm-|rocm_directory_version|/bin/rocminfo
+        /opt/rocm-|rocm_directory_version|/bin/clinfo
 
 5. Verify package installation.
 

--- a/docs/how-to/native-install/ubuntu.rst
+++ b/docs/how-to/native-install/ubuntu.rst
@@ -78,6 +78,7 @@ Add the ROCm repository.
                     | sudo tee --append /etc/apt/sources.list.d/rocm.list
                 echo -e 'Package: *\nPin: release o=repo.radeon.com\nPin-Priority: 600' \
                     | sudo tee /etc/apt/preferences.d/rocm-pin-600
+                sudo apt update
         {% endfor %}
 
 .. _ubuntu-install:


### PR DESCRIPTION
This adds the "sudo apt update" instruction to the Ubuntu install instructions in the ubuntu.rst file (in the Installation via Package Manager section). It also merges a fix from develop that corrects some variable names.