### PR TITLE
Port addition of sudo apt update to Ubuntu installation instructions …

### DIFF
--- a/docs/how-to/native-install/ubuntu.rst
+++ b/docs/how-to/native-install/ubuntu.rst
@@ -78,6 +78,7 @@ Add the ROCm repository.
                     | sudo tee --append /etc/apt/sources.list.d/rocm.list
                 echo -e 'Package: *\nPin: release o=repo.radeon.com\nPin-Priority: 600' \
                     | sudo tee /etc/apt/preferences.d/rocm-pin-600
+                sudo apt update
         {% endfor %}
 
 .. _ubuntu-install:


### PR DESCRIPTION
This ports a one-line change to add the `sudo apt update` instruction to the Ubuntu install instructions in ubuntu.rst.

The rest of the changes were not required because they are already in the docs/6.0.2 branch repository.