### PR TITLE
Fix Radeon link

### DIFF
--- a/docs/tutorial/install-overview.rst
+++ b/docs/tutorial/install-overview.rst
@@ -17,7 +17,7 @@ If you're new to ROCm, we recommend using the :ref:`rocm-install-quick`.
 
 .. note::
     If you're using a Radeon GPU with graphical applications, refer to the
-    :doc:`Radeon installation instructions <radeon:index>`.
+    `Radeon installation instructions <https://rocm.docs.amd.com/projects/radeon/en/latest/index.html>`_.
 
 Package manager versus AMDGPU installer
 ===========================================================


### PR DESCRIPTION
Versions on the Radeon page don't map 1:1 with ROCm docs. This breaks Intersphinx links for most ROCm docs versions.

Workaround :: I guess just point to latest Radeon docs.