### PR TITLE
build: Update rocm-docs-core to 1.4.1

### DIFF
--- a/docs/sphinx/requirements.in
+++ b/docs/sphinx/requirements.in
@@ -1,3 +1,3 @@
-rocm-docs-core==1.4.0
+rocm-docs-core==1.4.1
 Sphinx-Substitution-Extensions==2024.2.25
 sphinxcontrib.datatemplates==0.11.0

--- a/docs/sphinx/requirements.txt
+++ b/docs/sphinx/requirements.txt
@@ -40,7 +40,7 @@ docutils==0.21.2
     #   sphinx
     #   sphinx-prompt
     #   sphinx-substitution-extensions
-fastjsonschema==2.19.1
+fastjsonschema==2.20.0
     # via rocm-docs-core
 gitdb==4.0.11
     # via gitpython
@@ -66,13 +66,13 @@ mdurl==0.1.2
     # via markdown-it-py
 myst-parser==3.0.1
     # via rocm-docs-core
-packaging==24.0
+packaging==24.1
     # via
     #   pydata-sphinx-theme
     #   sphinx
 pycparser==2.22
     # via cffi
-pydata-sphinx-theme==0.15.3
+pydata-sphinx-theme==0.15.4
     # via
     #   rocm-docs-core
     #   sphinx-book-theme
@@ -98,7 +98,7 @@ requests==2.32.3
     # via
     #   pygithub
     #   sphinx
-rocm-docs-core==1.4.0
+rocm-docs-core==1.4.1
     # via -r requirements.in
 smmap==5.0.1
     # via gitdb
@@ -121,7 +121,7 @@ sphinx==7.3.7
     #   sphinx-substitution-extensions
     #   sphinxcontrib-datatemplates
     #   sphinxcontrib-runcmd
-sphinx-book-theme==1.1.2
+sphinx-book-theme==1.1.3
     # via rocm-docs-core
 sphinx-copybutton==0.5.2
     # via rocm-docs-core
@@ -153,11 +153,11 @@ sphinxcontrib-serializinghtml==1.1.10
     # via sphinx
 tomli==2.0.1
     # via sphinx
-typing-extensions==4.12.1
+typing-extensions==4.12.2
     # via
     #   pydata-sphinx-theme
     #   pygithub
-urllib3==2.2.1
+urllib3==2.2.2
     # via
     #   pygithub
     #   requests


### PR DESCRIPTION
For the header update (GitHub link will direct to this repository instead of ROCm/ROCm)