### PR TITLE
UCC 1.3. should be used with ROCm 6.1 onward

### DIFF
--- a/docs/reference/3rd-party-support-matrix.rst
+++ b/docs/reference/3rd-party-support-matrix.rst
@@ -105,6 +105,9 @@ support for ROCm devices.
     * - ROCm version
       - UCC version
 
+    * - >= 6.1.0
+      - >= 1.3.0
+
     * - >= 5.6.0
       - >= 1.2.0
 


### PR DESCRIPTION
Update the UCC compatibility matrix for ROCm 6.3. UCC 1.3 was not released in time for ROCm 6.1, hence the delay in updating the table