### PR TITLE
Updated build from source instructions to resolve issue #259

### DIFF
--- a/docs/install/rocm-offline-installer.rst
+++ b/docs/install/rocm-offline-installer.rst
@@ -682,13 +682,13 @@ To build the Offline Installer Creator:
 
    .. code-block:: shell 
 
-      git clone git@github.com:ROCm/rocm-install-on-linux.git
+      git clone https://github.com/ROCm/rocm-install-on-linux
 
 #. Build the configuration
 
    .. code-block:: shell 
 
-      cd src/offline-install
+      cd rocm-install-on-linux/src/offline-install
       mkdir build 
       cd build
       cmake ..

--- a/docs/install/rocm-offline-installer.rst
+++ b/docs/install/rocm-offline-installer.rst
@@ -71,7 +71,7 @@ Download the Offline Installer Creator from ``repo.radeon.com`` using the follow
 
 .. code-block:: shell
 
-   wget https://repo.radeon.com/rocm/installer/rocm-linux-install-offline/<rocm-version>/<distro>/<distro-version>/<creator-package>
+   wget https://repo.radeon.com/rocm/installer/rocm-linux-install-offline/rocm-rel-<rocm-version>/<distro>/<distro-version>/<creator-package>
 
 Substitute your values for the following placeholders:
 
@@ -85,7 +85,7 @@ for Ubuntu release 22.04:
 
 .. code-block:: shell
 
-   wget https://repo.radeon.com/rocm/installer/rocm-linux-install-offline/rocm-rel-6.2/ubuntu/22.04/rocm-offline-creator_1.0.0.60200-1~22.04.run
+   wget https://repo.radeon.com/rocm/installer/rocm-linux-install-offline/rocm-rel-6.2/ubuntu/22.04/rocm-offline-creator_1.0.0.60200-3~22.04.run
 
 Installer Creation
 ================================================

--- a/docs/install/rocm-offline-installer.rst
+++ b/docs/install/rocm-offline-installer.rst
@@ -688,7 +688,7 @@ To build the Offline Installer Creator:
 
    .. code-block:: shell 
 
-      cd rocm-install-on-linux/src/offline-install
+      cd rocm-install-on-linux/src/offline-installer
       mkdir build 
       cd build
       cmake ..

--- a/docs/sphinx/requirements.in
+++ b/docs/sphinx/requirements.in
@@ -1,3 +1,3 @@
-rocm-docs-core==1.6.1
-Sphinx-Substitution-Extensions==2024.2.25
+rocm-docs-core==1.6.2
+Sphinx-Substitution-Extensions==2024.8.6
 sphinxcontrib.datatemplates==0.11.0

--- a/docs/sphinx/requirements.txt
+++ b/docs/sphinx/requirements.txt
@@ -38,7 +38,6 @@ docutils==0.21.2
     #   myst-parser
     #   pydata-sphinx-theme
     #   sphinx
-    #   sphinx-prompt
     #   sphinx-substitution-extensions
 fastjsonschema==2.19.1
     # via rocm-docs-core
@@ -83,7 +82,6 @@ pygments==2.17.2
     #   accessible-pygments
     #   pydata-sphinx-theme
     #   sphinx
-    #   sphinx-prompt
 pyjwt[crypto]==2.8.0
     # via pygithub
 pynacl==1.5.0
@@ -98,7 +96,7 @@ requests==2.31.0
     # via
     #   pygithub
     #   sphinx
-rocm-docs-core==1.6.1
+rocm-docs-core==1.6.2
     # via -r requirements.in
 smmap==5.0.1
     # via gitdb
@@ -117,7 +115,6 @@ sphinx==7.3.7
     #   sphinx-design
     #   sphinx-external-toc
     #   sphinx-notfound-page
-    #   sphinx-prompt
     #   sphinx-substitution-extensions
     #   sphinxcontrib-datatemplates
     #   sphinxcontrib-runcmd
@@ -131,9 +128,7 @@ sphinx-external-toc==1.0.1
     # via rocm-docs-core
 sphinx-notfound-page==1.0.0
     # via rocm-docs-core
-sphinx-prompt==1.8.0
-    # via sphinx-substitution-extensions
-sphinx-substitution-extensions==2024.2.25
+sphinx-substitution-extensions==2024.8.6
     # via -r requirements.in
 sphinxcontrib-applehelp==1.0.8
     # via sphinx


### PR DESCRIPTION
This pull request resolves issue #259 

- changed `git@github.com:ROCm/rocm-install-on-linux.git` to `https://github.com/ROCm/rocm-install-on-linux`
- updated step 3 to `cd rocm-install-on-linux/src/offline-installer`