### PR TITLE
Cherry-pick to docs/6.2.1: Fix broken link in Ubuntu 20.04 tab of Docker support matrix

### DIFF
--- a/docs/reference/docker-image-support-matrix.rst
+++ b/docs/reference/docker-image-support-matrix.rst
@@ -102,8 +102,8 @@ The following Docker image tags and associated inventories are validated for ROC
                  * `ROCm 6.2 <https://repo.radeon.com/rocm/apt/6.2/>`_
                  * `Python 3.9 <https://www.python.org/downloads/release/python-3918/>`_
                  * `PyTorch 2.2.1 <https://github.com/ROCm/pytorch/tree/release/2.2>`_
-                 * `Apex 1.2.0 <https://github.com/ROCm/apex/tree/1.2.0>`_
-                 * `torchvision 0.17.1 <https://github.com/pytorch/vision/tree/v0.17>`_
+                 * `Apex 1.2.0 <https://github.com/ROCm/apex/tree/release/1.2.0>`_
+                 * `torchvision 0.17.1 <https://github.com/pytorch/vision/tree/v0.17.1>`_
                  * `TensorBoard 2.13.0 <https://github.com/tensorflow/tensorboard/tree/2.13>`_
                  * `MAGMA <https://bitbucket.org/icl/magma/src/master/>`_
                  * `UCX 1.10.0 <https://github.com/openucx/ucx/tree/v1.10.0>`_
@@ -121,7 +121,7 @@ The following Docker image tags and associated inventories are validated for ROC
                  * `ROCm 6.2 <https://repo.radeon.com/rocm/apt/6.2/>`_
                  * `Python 3.9 <https://www.python.org/downloads/release/python-3918/>`_
                  * `PyTorch 2.1.2 <https://github.com/ROCm/pytorch/tree/release/2.1>`_
-                 * `Apex 1.1.0 <https://github.com/ROCm/apex/tree/1.1.0>`_
+                 * `Apex 1.1.0 <https://github.com/ROCm/apex/tree/release/1.1.0>`_
                  * `torchvision 0.16.1 <https://github.com/pytorch/vision/tree/release/0.16>`_
                  * `TensorBoard 2.13.0 <https://github.com/tensorflow/tensorboard/tree/2.13>`_
                  * `MAGMA <https://bitbucket.org/icl/magma/src/master/>`_
@@ -140,8 +140,8 @@ The following Docker image tags and associated inventories are validated for ROC
                  * `ROCm 6.2 <https://repo.radeon.com/rocm/apt/6.2/>`_
                  * `Python 3.9 <https://www.python.org/downloads/release/python-3918/>`_
                  * `PyTorch 1.13.1 <https://github.com/ROCm/pytorch/tree/release/1.13>`_
-                 * `Apex 1.0.0 <https://github.com/ROCm/apex/tree/1.0.0>`_
-                 * `torchvision 0.14.0 <https://github.com/pytorch/vision/tree/release/0.14.0>`_
+                 * `Apex 1.0.0 <https://github.com/ROCm/apex/tree/release/1.0.0>`_
+                 * `torchvision 0.14.0 <https://github.com/pytorch/vision/tree/v0.14.0>`_
                  * `TensorBoard 2.17.0 <https://github.com/tensorflow/tensorboard/tree/2.17.0>`_
                  * `MAGMA <https://bitbucket.org/icl/magma/src/master/>`_
                  * `UCX 1.10.0 <https://github.com/openucx/ucx/tree/v1.10.0>`_


### PR DESCRIPTION
I made a typo in my local branch name. It's based on a checkout of upstream/docs/6.2.1. Sorry for the confusion!