### PR TITLE
update PyTorch install to include 24.04

### DIFF
--- a/docs/install/3rd-party/pytorch-install.rst
+++ b/docs/install/3rd-party/pytorch-install.rst
@@ -75,38 +75,38 @@ wheels command, you must select 'Linux', 'Python', 'pip', and 'ROCm' in the matr
 
           * - Base OS
             - Docker Image
-          * - Ubuntu 20.04
-            - `rocm/dev-ubuntu-20.04 <https://hub.docker.com/r/rocm/dev-ubuntu-20.04>`_
           * - Ubuntu 22.04
             - `rocm/dev-ubuntu-22.04 <https://hub.docker.com/r/rocm/dev-ubuntu-22.04>`_
+          * - Ubuntu 24.04
+            - `rocm/dev-ubuntu-24.04 <https://hub.docker.com/r/rocm/dev-ubuntu-24.04>`_
 
    b. Pull the selected image.
 
    .. code-block:: bash
 
-       docker pull rocm/dev-ubuntu-20.04:latest
+       docker pull rocm/dev-ubuntu-22.04:latest
 
    c. Start a Docker container using the downloaded image.
 
    .. code-block:: bash
 
-       docker run -it --device=/dev/kfd --device=/dev/dri --group-add video rocm/dev-ubuntu-20.04:latest
+       docker run -it --device=/dev/kfd --device=/dev/dri --group-add video rocm/dev-ubuntu-22.04:latest
 
    **Option 2:**
 
    Select a base OS Docker image (Check :ref:`system-requirements`)
 
-   Pull selected base OS image (Ubuntu 20.04 for example)
+   Pull selected base OS image (Ubuntu 22.04 for example)
 
    .. code-block:: bash
 
-       docker pull ubuntu:20.04
+       docker pull ubuntu:22.04
 
    Start a Docker container using the downloaded image
 
    .. code-block:: bash
 
-       docker run -it --device=/dev/kfd --device=/dev/dri --group-add video ubuntu:20.04
+       docker run -it --device=/dev/kfd --device=/dev/dri --group-add video ubuntu:22.04
 
    Install ROCm using the directions in the :ref:`rocm-install-overview` section.
 


### PR DESCRIPTION
We are moving away from 20.04 support (so changed the instructions to use 22.04), we should also add 24.04 docker links.  Thoughts @jithunnair-amd 