### PR TITLE
DisableIGP added to prerequisites and remove 24.04 multi-version inst…

### DIFF
--- a/.wordlist.txt
+++ b/.wordlist.txt
@@ -12,6 +12,7 @@ FWDEV
 hostname
 hotplug
 IFWI
+IGP
 IIO
 IRQs
 MACVTAP

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -6,7 +6,8 @@
 
 # ROCm version numbers
 rocm_version = '6.2'
-rocm_multi_versions = '6.2.0 6.1.2'
+rocm_multi_versions = '6.2 6.1.2' # in 6.2, the folder names on repo.radeon.com use 6.2 for minor releases
+rocm_multi_versions_package_versions = '6.2.0 6.1.2' # however, in multi, the packages use 6.2.0
 rocm_directory_version = '6.2.0' # in 6.0 rocm was located in /opt/rocm-6.0.0
 amdgpu_version = '6.2' # directory in https://repo.radeon.com/rocm/apt/ and https://repo.radeon.com/amdgpu-install/
 amdgpu_install_version = '6.2.60200-1' # version in https://repo.radeon.com/amdgpu-install/6.0.2/ubuntu/jammy/
@@ -66,6 +67,7 @@ external_projects_current_project = "rocm"
 rst_prolog = f"""
 .. |rocm_version| replace:: {rocm_version}
 .. |rocm_multi_versions| replace:: {rocm_multi_versions}
+.. |rocm_multi_versions_package_versions| replace:: {rocm_multi_versions_package_versions}
 .. |amdgpu_version| replace:: {amdgpu_version}
 .. |rocm_directory_version| replace:: {rocm_directory_version}
 .. |amdgpu_install_version| replace:: {amdgpu_install_version}

--- a/docs/install/native-install/includes/rhel-multi-install.rst
+++ b/docs/install/native-install/includes/rhel-multi-install.rst
@@ -69,7 +69,7 @@
       .. code-block:: bash
          :substitutions:
 
-         for ver in |rocm_multi_versions|; do
+         for ver in |rocm_multi_versions_package_versions|; do
              sudo dnf install rocm$ver
          done
 

--- a/docs/install/native-install/includes/sles-multi-install.rst
+++ b/docs/install/native-install/includes/sles-multi-install.rst
@@ -34,7 +34,7 @@
       .. code-block:: bash
          :substitutions:
 
-         for ver in |rocm_multi_versions|; do
+         for ver in |rocm_multi_versions_package_versions|; do
              sudo zypper --gpg-auto-import-keys install rocm$ver
          done
 

--- a/docs/install/native-install/includes/ubuntu-multi-install.rst
+++ b/docs/install/native-install/includes/ubuntu-multi-install.rst
@@ -10,6 +10,9 @@
 
        .. tab-set::
            {% for (os_version, os_release) in config.html_context['ubuntu_version_numbers'] %}
+           {% if os_version == '24.04' %}
+               
+           {% else %}
            .. tab-item:: Ubuntu {{ os_version }}
                :sync: ubuntu-{{ os_version}}
 
@@ -21,6 +24,8 @@
                        | sudo tee /etc/apt/sources.list.d/amdgpu.list
                    done
                    sudo apt update
+
+           {% endif %}
            {% endfor %}
 
 .. _ubuntu-multi-register-rocm:
@@ -33,6 +38,9 @@
 
       .. tab-set::
           {% for (os_version, os_release) in config.html_context['ubuntu_version_numbers'] %}
+          {% if os_version == '24.04' %}
+               
+          {% else %}
           .. tab-item:: Ubuntu {{ os_version }}
               :sync: ubuntu-{{ os_version}}
   
@@ -46,6 +54,7 @@
                   echo -e 'Package: *\nPin: release o=repo.radeon.com\nPin-Priority: 600' \
                       | sudo tee /etc/apt/preferences.d/rocm-pin-600
                   sudo apt update
+          {% endif %}
           {% endfor %}
 
 4. Install ROCm.
@@ -62,11 +71,17 @@
       .. code-block:: bash
          :substitutions:
 
-         for ver in |rocm_multi_versions|; do
+         for ver in |rocm_multi_versions_package_versions|; do
              sudo apt install rocm$ver
          done
 
 5. Complete the :doc:`../post-install`.
+
+.. note::
+
+   Since Ubuntu 24.04 is newly supported with ROCm 6.2, we only have one package to 
+   install on Ubuntu 24.04. As a result, multi-version support is not available for
+   Ubuntu 24.04 as there are no additional versions at this time.
 
 .. tip::
 

--- a/docs/install/prerequisites.rst
+++ b/docs/install/prerequisites.rst
@@ -67,13 +67,23 @@ your operating system to ensure you're able to download and install packages.
         Typically you can register by following the step-by-step user interface.
         If you need to register by command line, use the following commands:
 
-        .. code-block:: shell
+        .. datatemplate:nodata::
+            
+           .. tab-set::
 
-            subscription-manager register --username <username> --password <password>
-            subscription-manager attach --auto
-            subscription-manager repos --enable codeready-builder-for-rhel-9-x86_64-rpms
+              {% for os_release in config.html_context['rhel_release_version_numbers']  %}
 
-        More details about `registering for RHEL <https://access.redhat.com/solutions/253273>`_
+                .. tab-item:: RHEL {{ os_release }}
+        
+                    .. code-block:: shell
+
+                       subscription-manager register --username <username> --password <password>
+                       subscription-manager attach --auto
+                       subscription-manager repos --enable codeready-builder-for-rhel-{{ os_release }}-x86_64-rpms
+
+           {% endfor %}
+
+           More details about `registering for RHEL <https://access.redhat.com/solutions/253273>`_
 
   .. tab-item:: SUSE Linux Enterprise Server
         :sync: sle-tab
@@ -81,14 +91,25 @@ your operating system to ensure you're able to download and install packages.
         Typically you can register by following the step-by-step user interface.
         If you need to register by command line, use the following commands:
 
-        .. code-block:: shell
+        .. datatemplate:nodata::
 
-            SUSEConnect -r <REGCODE>
-            SUSEConnect -p sle-module-desktop-application/15.4/x86_64
-            SUSEConnect -p sle-module-development-tools/15.4/x86_64
-            SUSEConnect -p PackageHub/15.4/x86_64
+            .. tab-set::
 
-        More details about `registering for SLES <https://www.suse.com/support/kb/doc/?id=000018564>`_
+                {% for os_version in config.html_context['sles_version_numbers'] %}
+                {% set os_release, os_sp  = os_version.split('.') %}
+
+                .. tab-item:: SLES {{ os_version }}
+                   
+                   .. code-block:: shell
+
+                      SUSEConnect -r <REGCODE>
+                      SUSEConnect -p sle-module-desktop-application/{{ os_version }}/x86_64
+                      SUSEConnect -p sle-module-development-tools/{{ os_version }}/x86_64
+                      SUSEConnect -p PackageHub/{{ os_version }}/x86_64
+
+                {% endfor %}
+
+            More details about `registering for SLES <https://www.suse.com/support/kb/doc/?id=000018564>`_
 
 
 Additional package repositories
@@ -220,3 +241,11 @@ recommend using the video group for all ROCm-supported operating systems.
 .. tip::
 
     On systems with multiple users, if ROCm is installed system wide, each individual user should be added to the ``render`` and ``video`` groups. 
+
+Disable integrated graphics (IGP), if applicable
+================================================================
+
+ROCm doesn't currently support integrated graphics. Should your system have an
+AMD IGP installed, disable it in the BIOS prior to using ROCm. If the driver can
+enumerate the IGP, the ROCm runtime may crash the system, even if told to omit
+it via `HIP_VISIBLE_DEVICES <https://rocm.docs.amd.com/en/latest/conceptual/gpu-isolation.html#hip-visible-devices>`_.


### PR DESCRIPTION
…all instructions (#279)

* add DisableIGP comment in prerequisites

* expand prerequisites to tabs for Registering your enterprise linux

* workaround for Ubuntu 24.04 multiversion, to limit and not mention 6.1.2 because noble not supported on 6.1.2

* multi version needs to differentiate from repo.radeon.com folder path, and actual package version

* Adding to wordlist

* fix tabs

* fix tabs again

* remove 24.04 mutli-version because we don't have multiple packages supported on 24.04 yet

* text update, thanks Harry

* fix Ubuntu typo