### PR TITLE
Updated Pre-Req Section

### DIFF
--- a/docs/install/prerequisites.rst
+++ b/docs/install/prerequisites.rst
@@ -80,7 +80,6 @@ your operating system to ensure you're able to download and install packages.
                        subscription-manager register --username <username> --password <password>
                        subscription-manager attach --auto
                        
-
            {% endfor %}
 
            More details about `registering for RHEL <https://access.redhat.com/solutions/253273>`_

--- a/docs/install/prerequisites.rst
+++ b/docs/install/prerequisites.rst
@@ -103,7 +103,7 @@ your operating system to ensure you're able to download and install packages.
                    .. code-block:: shell
 
                       SUSEConnect -r <REGCODE>
-                      SUSEConnect -p sle-module-desktop-application/{{ os_version }}/x86_64
+                      SUSEConnect -p sle-module-desktop-applications/{{ os_version }}/x86_64
                       SUSEConnect -p sle-module-development-tools/{{ os_version }}/x86_64
                       SUSEConnect -p PackageHub/{{ os_version }}/x86_64
 

--- a/docs/install/prerequisites.rst
+++ b/docs/install/prerequisites.rst
@@ -79,7 +79,7 @@ your operating system to ensure you're able to download and install packages.
 
                        subscription-manager register --username <username> --password <password>
                        subscription-manager attach --auto
-                       subscription-manager repos --enable codeready-builder-for-rhel-{{ os_release }}-x86_64-rpms
+                       
 
            {% endfor %}
 


### PR DESCRIPTION
SUSEConnect -p sle-module-desktop-applications/<version>/x86_64

"s" is missing so corrected. 

If any user will try to install in existing format without "s" , repo will not get enabled and driver install will throw the error

# amdgpu-install --usecase=rocm --no-dkms
Refreshing service 'container-suseconnect-zypp'.
Loading repository data...
Reading installed packages...
Resolving package dependencies...
 
Problem: 1: nothing provides 'libva2' needed by the to be installed rocdecode-0.6.0.60200-sles155.66.x86_64
Solution 1: do not install rocm-6.2.0.60200-sles155.66.x86_64
Solution 2: break rocdecode-0.6.0.60200-sles155.66.x86_64 by ignoring some of its dependencies
 
Choose from above solutions by number or cancel [1/2/c/d/?] (c): c