### PR TITLE
Correct spack install command

### DIFF
--- a/docs/how-to/spack.rst
+++ b/docs/how-to/spack.rst
@@ -82,7 +82,7 @@ Building ROCm components using Spack
    .. code-block:: shell
 
       cd spack
-      ./share/spack/setup-env.sh
+      . share/spack/setup-env.sh
 
    Spack commands are available once the above steps are completed. To list the available commands, use ``help``.
 


### PR DESCRIPTION
Update command on install instructions to mirror [official documentation](https://spack.readthedocs.io/en/latest/getting_started.html#shell-support) and our own internal installation. This will execute the script in the current shell and setup the spack environment. 