### PR TITLE
Add tensorflow wheel versioning note

### DIFF
--- a/.wordlist.txt
+++ b/.wordlist.txt
@@ -22,7 +22,7 @@ PLX
 preconfigured
 Repo
 rocHPL
-ROCmVersionWithoutCommas
+ROCmVersion
 SBR
 SMCi
 SVM

--- a/docs/install/3rd-party/tensorflow-install.rst
+++ b/docs/install/3rd-party/tensorflow-install.rst
@@ -87,8 +87,7 @@ To install TensorFlow using the wheels package, use the following command.
 
 .. note::
 
-   For details on ``tensorflow-rocm`` wheels and ROCm version compatibility, refer to
-   `<https://github.com/ROCm/tensorflow-upstream/blob/develop-upstream/rocm_docs/tensorflow-rocm-release.md>`__.
+   Prior to ROCm 6.1, ``[wheel-version]`` followed the ``<TensorFlowVersion>.<ROCmVersion>`` format.
 
 .. _test-tensorflow-installation:
 

--- a/docs/reference/3rd-party-support-matrix.rst
+++ b/docs/reference/3rd-party-support-matrix.rst
@@ -13,8 +13,7 @@ ROCm™ supports a variety of third-party libraries and frameworks. The supporte
 Deep learning
 ================================================
 
-ROCm releases support the most recent and two prior releases of PyTorch and
-TensorFlow. For TensorFlow the exact version follows the ``<TensorFlowVersion>.<ROCmVersionWithoutCommas>`` format.
+ROCm releases support the most recent and two prior releases of PyTorch and TensorFlow.
 
 .. list-table::
     :header-rows: 1


### PR DESCRIPTION
Prior to 6.1, tensorflow-rocm wheels were hosted on PyPi and used `<TensorFlowVersion>.<ROCmVersion>`. They now use just the `<TensorFlowVersion>`. Changes in this PR include

1. Removed old note pointing to [ROCm/tensorflow-upstream](https://github.com/ROCm/tensorflow-upstream/blob/develop-upstream/rocm_docs/tensorflow-rocm-release.md) which is deprecated/incorrect.
2. Added note highlighting the difference in versioning schema.
3. Removed line on 3rd Party Support Matrix page that specifies old versioning schema.
4. Updated .wordlist.txt though I'm not sure if that's neccesary