### PR TITLE
Add instructions for using udev to manage GPU access

### DIFF
--- a/.wordlist.txt
+++ b/.wordlist.txt
@@ -34,3 +34,4 @@ vfio
 VFIO
 vhost
 udev
+Udev

--- a/.wordlist.txt
+++ b/.wordlist.txt
@@ -6,6 +6,7 @@ CTest
 DHCP
 dkms
 dmesg
+DRM
 fw
 FW
 FWDEV
@@ -32,3 +33,5 @@ vCPU
 vfio
 VFIO
 vhost
+udev
+Udev

--- a/.wordlist.txt
+++ b/.wordlist.txt
@@ -34,4 +34,3 @@ vfio
 VFIO
 vhost
 udev
-Udev

--- a/docs/install/prerequisites.rst
+++ b/docs/install/prerequisites.rst
@@ -195,10 +195,9 @@ To install for the currently active kernel run the command corresponding to your
 Configuring permissions for GPU access
 ================================================================
 
-ROCm requires users to have access to GPU resources. There are two primary methods to 
-configure GPU access for ROCm: using udev rules or managing group membership. Each method has 
-its own advantages, and the choice depends on your specific requirements and system management 
-preferences.
+There are two primary methods to configure GPU access for ROCm: using udev rules 
+or managing group membership. Each method has its own advantages, and the choice 
+depends on your specific requirements and system management preferences.
 
 Using udev Rules (Recommended)
 --------------------------------------------------------------------

--- a/docs/install/prerequisites.rst
+++ b/docs/install/prerequisites.rst
@@ -195,19 +195,10 @@ To install for the currently active kernel run the command corresponding to your
 Configuring permissions for GPU access
 ================================================================
 
-ROCm requires users to have access to GPU resources. Proper configuration ensures that 
-users can utilize the full capabilities of AMD GPUs while maintaining system security. 
-There are multiple ways to configure this access, each with its own advantages.
-
-The ``video`` and ``render`` groups are system groups in Linux used to manage access 
-to graphics hardware and related functionality. Traditionally, the ``video`` group is used 
-to control access to video devices, including graphics cards and video capture devices. 
-The ``render`` group is more recent and specifically controls access to GPU rendering capabilities 
-through Direct Rendering Manager (DRM) render nodes.
-
-There are two primary methods to configure GPU access for ROCm: using udev rules or managing group membership. 
-Each method has its own advantages, and the choice depends on your specific requirements 
-and system management preferences.
+ROCm requires users to have access to GPU resources. There are two primary methods to 
+configure GPU access for ROCm: using udev rules or managing group membership. Each method has 
+its own advantages, and the choice depends on your specific requirements and system management 
+preferences.
 
 Using udev Rules (Recommended)
 --------------------------------------------------------------------
@@ -272,6 +263,11 @@ Using Group Membership
 --------------------------------------------------------------------
 
 Alternatively, you can manage GPU access through membership in the ``video`` and ``render`` groups.
+The ``video`` and ``render`` groups are system groups in Linux used to manage access 
+to graphics hardware and related functionality. Traditionally, the ``video`` group is used 
+to control access to video devices, including graphics cards and video capture devices. 
+The ``render`` group is more recent and specifically controls access to GPU rendering capabilities 
+through Direct Rendering Manager (DRM) render nodes.
 
 1. To check the groups in your system, issue the following command:
 

--- a/docs/install/prerequisites.rst
+++ b/docs/install/prerequisites.rst
@@ -210,14 +210,14 @@ Grant GPU access to all users on the system
 
 1. Create a new file ``/etc/udev/rules.d/70-amdgpu.rules`` with the following content:
 
-   .. code-block:: bash
+   .. code-block:: shell
 
       KERNEL=="kfd", MODE="0666"
       SUBSYSTEM=="drm", KERNEL=="renderD*", MODE="0666"
 
 2. Reload the udev rules:
 
-   .. code-block:: bash
+   .. code-block:: shell
 
       sudo udevadm control --reload-rules && sudo udevadm trigger
 
@@ -229,13 +229,13 @@ Grant GPU access to a custom group
 
 1. Create a new group (e.g., ``devteam``):
 
-   .. code-block:: bash
+   .. code-block:: shell
 
       sudo groupadd devteam
 
 2. Add users to the new group:
 
-   .. code-block:: bash
+   .. code-block:: shell
 
       sudo usermod -a -G devteam dev1
       sudo usermod -a -G devteam dev2
@@ -244,14 +244,14 @@ Grant GPU access to a custom group
 
    Create a file ``/etc/udev/rules.d/70-amdgpu.rules`` with:
 
-   .. code-block:: bash
+   .. code-block:: shell
 
       KERNEL=="kfd", GROUP="devteam", MODE="0660"
       SUBSYSTEM=="drm", KERNEL=="renderD*", GROUP="devteam", MODE="0660"
 
 4. Reload the udev rules:
 
-   .. code-block:: bash
+   .. code-block:: shell
 
       sudo udevadm control --reload-rules && sudo udevadm trigger
 
@@ -276,20 +276,20 @@ through Direct Rendering Manager (DRM) render nodes.
 
 2. Add yourself to the ``video`` and ``render`` groups:
 
-   .. code-block:: bash
+   .. code-block:: shell
 
       sudo usermod -a -G video,render $LOGNAME
 
 3. Optionally, add other users to the ``video`` and ``render`` groups:
 
-   .. code-block:: bash
+   .. code-block:: shell
 
       sudo usermod -a -G video,render user1
       sudo usermod -a -G video,render user2
 
 4. To add all future users to the render and video groups by default, run the following commands:
 
-   .. code-block:: bash
+   .. code-block:: shell
 
       echo 'ADD_EXTRA_GROUPS=1' | sudo tee -a /etc/adduser.conf
       echo 'EXTRA_GROUPS=video' | sudo tee -a /etc/adduser.conf

--- a/docs/install/prerequisites.rst
+++ b/docs/install/prerequisites.rst
@@ -238,7 +238,7 @@ through Direct Rendering Manager (DRM) render nodes.
 
 Using udev rules
 --------------------------------------------------------------------
-Udev rules offer a flexible way to manage device permissions. They apply system-wide, can be 
+A flexible way to manage device permissions is to use udev rules. They apply system-wide, can be 
 easily deployed via configuration management tools, and eliminate the need for user group management. 
 This method provides more granular control over GPU access.
 

--- a/docs/install/prerequisites.rst
+++ b/docs/install/prerequisites.rst
@@ -195,11 +195,48 @@ To install for the currently active kernel run the command corresponding to your
 Configuring permissions for GPU access
 ================================================================
 
-There are two primary methods to configure GPU access for ROCm: using udev rules 
-or managing group membership. Each method has its own advantages, and the choice 
-depends on your specific requirements and system management preferences.
+There are two primary methods to configure GPU access for ROCm: group membership or
+udev rules. Each method has its own advantages, and the choice depends on your 
+specific requirements and system management preferences.
 
-Using udev Rules (Recommended)
+Using Group Membership
+--------------------------------------------------------------------
+
+By default, GPU access is managed through membership in the ``video`` and ``render`` groups.
+The ``video`` and ``render`` groups are system groups in Linux used to manage access 
+to graphics hardware and related functionality. Traditionally, the ``video`` group is used 
+to control access to video devices, including graphics cards and video capture devices. 
+The ``render`` group is more recent and specifically controls access to GPU rendering capabilities 
+through Direct Rendering Manager (DRM) render nodes.
+
+1. To check the groups in your system, issue the following command:
+
+   .. code-block:: shell
+
+       groups
+
+2. Add yourself to the ``video`` and ``render`` groups:
+
+   .. code-block:: shell
+
+      sudo usermod -a -G video,render $LOGNAME
+
+3. Optionally, add other users to the ``video`` and ``render`` groups:
+
+   .. code-block:: shell
+
+      sudo usermod -a -G video,render user1
+      sudo usermod -a -G video,render user2
+
+4. To add all future users to the render and video groups by default, run the following commands:
+
+   .. code-block:: shell
+
+      echo 'ADD_EXTRA_GROUPS=1' | sudo tee -a /etc/adduser.conf
+      echo 'EXTRA_GROUPS=video' | sudo tee -a /etc/adduser.conf
+      echo 'EXTRA_GROUPS=render' | sudo tee -a /etc/adduser.conf
+
+Using udev Rules
 --------------------------------------------------------------------
 Udev rules offer a flexible way to manage device permissions. They apply system-wide, can be 
 easily deployed via configuration management tools, and eliminate the need for user group management. 
@@ -257,43 +294,6 @@ Grant GPU access to a custom group
 
 This configuration grants all users in the ``devteam`` group read and write access to AMD GPU resources, 
 including the Kernel Fusion Driver (KFD) and Direct Rendering Manager (DRM) devices.
-
-Using Group Membership
---------------------------------------------------------------------
-
-Alternatively, you can manage GPU access through membership in the ``video`` and ``render`` groups.
-The ``video`` and ``render`` groups are system groups in Linux used to manage access 
-to graphics hardware and related functionality. Traditionally, the ``video`` group is used 
-to control access to video devices, including graphics cards and video capture devices. 
-The ``render`` group is more recent and specifically controls access to GPU rendering capabilities 
-through Direct Rendering Manager (DRM) render nodes.
-
-1. To check the groups in your system, issue the following command:
-
-   .. code-block:: shell
-
-       groups
-
-2. Add yourself to the ``video`` and ``render`` groups:
-
-   .. code-block:: shell
-
-      sudo usermod -a -G video,render $LOGNAME
-
-3. Optionally, add other users to the ``video`` and ``render`` groups:
-
-   .. code-block:: shell
-
-      sudo usermod -a -G video,render user1
-      sudo usermod -a -G video,render user2
-
-4. To add all future users to the render and video groups by default, run the following commands:
-
-   .. code-block:: shell
-
-      echo 'ADD_EXTRA_GROUPS=1' | sudo tee -a /etc/adduser.conf
-      echo 'EXTRA_GROUPS=video' | sudo tee -a /etc/adduser.conf
-      echo 'EXTRA_GROUPS=render' | sudo tee -a /etc/adduser.conf
 
 Disable integrated graphics (IGP), if applicable
 ================================================================

--- a/docs/install/prerequisites.rst
+++ b/docs/install/prerequisites.rst
@@ -199,7 +199,7 @@ There are two primary methods to configure GPU access for ROCm: group membership
 udev rules. Each method has its own advantages, and the choice depends on your 
 specific requirements and system management preferences.
 
-Using Group Membership
+Using group membership
 --------------------------------------------------------------------
 
 By default, GPU access is managed through membership in the ``video`` and ``render`` groups.

--- a/docs/install/prerequisites.rst
+++ b/docs/install/prerequisites.rst
@@ -236,7 +236,7 @@ through Direct Rendering Manager (DRM) render nodes.
       echo 'EXTRA_GROUPS=video' | sudo tee -a /etc/adduser.conf
       echo 'EXTRA_GROUPS=render' | sudo tee -a /etc/adduser.conf
 
-Using udev Rules
+Using udev rules
 --------------------------------------------------------------------
 Udev rules offer a flexible way to manage device permissions. They apply system-wide, can be 
 easily deployed via configuration management tools, and eliminate the need for user group management. 


### PR DESCRIPTION
I was asked to update the prerequisites page with a new section with instructions for using udev to manage GPU access. I have validated that these instructions work on the linux system I have available (Ubuntu 22.02). Please review and let me know if there are any additional edits needed.