### PR TITLE
Cherry-pick to docs/6.2.2: Remove dnf update from RHEL instructions (#333)

### DIFF
--- a/docs/install/quick-start.rst
+++ b/docs/install/quick-start.rst
@@ -54,7 +54,6 @@ For more in-depth installation instructions, refer to :ref:`detailed-install-ove
                    .. code-block:: bash
                        :substitutions:
 
-                       sudo dnf update
                        wget https://dl.fedoraproject.org/pub/epel/epel-release-latest-{{ os_major }}.noarch.rpm
                        sudo rpm -ivh epel-release-latest-{{ os_major }}.noarch.rpm
                        sudo dnf install dnf-plugin-config-manager


### PR DESCRIPTION
(cherry picked from commit 7b93ca8ab7ca3d55db6a397e1e87ed6180eb46bf)