### PR TITLE
Fix typos in docker-compose example

### DIFF
--- a/docs/how-to/docker.rst
+++ b/docs/how-to/docker.rst
@@ -66,8 +66,8 @@ remember all the CLI arguments. Here is a docker-compose file, which is equivale
     services:
       my-service:
         image: <image>
-        device:
-          - /dev/fdk
+        devices:
+          - /dev/kfd
           - /dev/dri
         security_opt:
           - seccomp:unconfined


### PR DESCRIPTION
Changed the device file from `/dev/fdk` to `/dev/kfd`

Changed the `device` field to `devices`, leaving it as `device` gave this error when running the service:
`validating /home/rocm/docker/compose.yaml: services.test Additional property device is not allowed`

https://docs.docker.com/reference/compose-file/services/#devices