### PR TITLE
Fix typos in docker-compose example 6.2.0

### DIFF
--- a/docs/how-to/docker.rst
+++ b/docs/how-to/docker.rst
@@ -66,8 +66,8 @@ remember all the CLI arguments. Here is a docker-compose file, which is equivale
     services:
       my-service:
         image: <image>
-        device:
-          - /dev/fdk
+        devices:
+          - /dev/kfd
           - /dev/dri
         security_opt:
           - seccomp:unconfined


### PR DESCRIPTION
(cherry picked from commit f297bde3afa98d750d1aa460386491db9a721f30)