### PR TITLE
Fix multi-version installation instruction

### DIFF
--- a/docs/install/native-install/includes/rhel-multi-install.rst
+++ b/docs/install/native-install/includes/rhel-multi-install.rst
@@ -13,7 +13,7 @@
               .. code-block:: bash
                   :substitutions:
 
-                  for ver in |rocm_multi_versions|; do
+                  ver = |amdgpu_version|
                   sudo tee /etc/yum.repos.d/amdgpu.repo <<EOF
                   [amdgpu]
                   name=amdgpu
@@ -23,7 +23,6 @@
                   gpgcheck=1
                   gpgkey=https://repo.radeon.com/rocm/rocm.gpg.key
                   EOF
-                  done
                   sudo dnf clean all
           {% endfor %}
 
@@ -44,7 +43,7 @@
                  for ver in |rocm_multi_versions|; do
                  sudo tee --append /etc/yum.repos.d/rocm.repo <<EOF
                  [ROCm-$ver]
-                 name=ROCm|rocm_version|
+                 name=ROCm$ver
                  baseurl=https://repo.radeon.com/rocm/el{{ os_release }}/$ver/main
                  enabled=1
                  priority=50

--- a/docs/install/native-install/includes/sles-multi-install.rst
+++ b/docs/install/native-install/includes/sles-multi-install.rst
@@ -1,24 +1,56 @@
 .. _sles-multi-install:
 
-1. Register the kernel-mode driver following the steps in :ref:`sles-register-driver`.
+1. Register the kernel-mode driver.
+
+   .. datatemplate:nodata::
+
+      .. tab-set::
+          {% for os_version in config.html_context['sles_version_numbers'] %}
+          {% set os_major, _  = os_version.split('.') %}
+          .. tab-item:: SLES {{ os_version }}
+              :sync: sles-{{ os_version }} sles-{{ os_major }}
+
+              .. code-block:: bash
+                  :substitutions:
+
+                  ver = |amdgpu_version|
+                  sudo tee /etc/zypp/repos.d/amdgpu.repo <<EOF
+                  [amdgpu]
+                  name=amdgpu
+                  baseurl=https://repo.radeon.com/amdgpu/$ver/sle/15.6/main/x86_64/
+                  enabled=1
+                  gpgcheck=1
+                  gpgkey=https://repo.radeon.com/rocm/rocm.gpg.key
+                  EOF
+                  sudo zypper ref
+          {% endfor %}
+
+.. _sles-multi-register-rocm:
 
 2. Register ROCm packages.
 
-   .. code-block:: bash
-      :substitutions:
+   .. datatemplate:nodata::
 
-      for ver in |rocm_multi_versions|; do
-      sudo tee --append /etc/zypp/repos.d/rocm.repo <<EOF
-      [ROCm-$ver]
-      name=ROCm$ver
-      baseurl=https://repo.radeon.com/rocm/zyp/$ver/main
-      enabled=1
-      gpgcheck=1
-      gpgkey=https://repo.radeon.com/rocm/rocm.gpg.key
-      EOF
-      done
+      .. tab-set::
+         {% for os_release in config.html_context['sles_release_version_numbers']  %}
+         .. tab-item:: SLES {{ os_release }}
+             :sync: sles-{{ os_release }}
 
-      sudo zypper ref
+             .. code-block:: bash
+                 :substitutions:
+
+                 for ver in |rocm_multi_versions|; do
+                 sudo tee --append /etc/zypp/repos.d/rocm.repo <<EOF
+                 [ROCm-$ver]
+                 name=ROCm$ver
+                 baseurl=https://repo.radeon.com/rocm/zyp/$ver/main
+                 enabled=1
+                 gpgcheck=1
+                 gpgkey=https://repo.radeon.com/rocm/rocm.gpg.key
+                 EOF
+                 done
+                 sudo zypper ref
+         {% endfor %}
 
 3. Install ROCm.
 

--- a/docs/install/native-install/includes/sles-multi-install.rst
+++ b/docs/install/native-install/includes/sles-multi-install.rst
@@ -17,7 +17,7 @@
                   sudo tee /etc/zypp/repos.d/amdgpu.repo <<EOF
                   [amdgpu]
                   name=amdgpu
-                  baseurl=https://repo.radeon.com/amdgpu/$ver/sle/15.6/main/x86_64/
+                  baseurl=https://repo.radeon.com/amdgpu/$ver/sle/{{ os_version }}/main/x86_64/
                   enabled=1
                   gpgcheck=1
                   gpgkey=https://repo.radeon.com/rocm/rocm.gpg.key

--- a/docs/install/native-install/includes/ubuntu-multi-install.rst
+++ b/docs/install/native-install/includes/ubuntu-multi-install.rst
@@ -16,10 +16,9 @@
                .. code-block:: bash
                    :substitutions:
 
-                   for ver in |rocm_multi_versions|; do
+                   ver = |amdgpu_version|
                    echo "deb [arch=amd64 signed-by=/etc/apt/keyrings/rocm.gpg] https://repo.radeon.com/amdgpu/$ver/ubuntu {{ os_release }} main" \
                        | sudo tee /etc/apt/sources.list.d/amdgpu.list
-                   done
                    sudo apt update
 
            {% endfor %}


### PR DESCRIPTION
- Previous version used a loop to register the driver. It doesn't make sense since it is a overwrite operation. Change to use the latest version to register the driver
- Fixed an error in the rhel instruction ( name=ROCm|rocm_version|, only install the latest ROCm since rocm_version is static)
- Refactored SLES section for consistency