### PR TITLE
Update NPM install for parity with amdgpu-install

### DIFF
--- a/docs/install/native-install/ubuntu.rst
+++ b/docs/install/native-install/ubuntu.rst
@@ -56,7 +56,7 @@ Add the AMDGPU repository for the driver.
             .. code-block:: bash
                 :substitutions:
 
-                echo "deb [arch=amd64 signed-by=/etc/apt/keyrings/rocm.gpg] https://repo.radeon.com/amdgpu/|rocm_version|/ubuntu {{ os_release }} main" \
+                echo "deb [arch=amd64,i386 signed-by=/etc/apt/keyrings/rocm.gpg] https://repo.radeon.com/amdgpu/|rocm_version|/ubuntu {{ os_release }} main" \
                     | sudo tee /etc/apt/sources.list.d/amdgpu.list
                 sudo apt update
         {% endfor %}


### PR DESCRIPTION
Updating Native Package Manager Install steps to specify supported architectures for 32/64 bit graphics runtimes.

This will allow systems to pull the correct i386/amd64 packages while also preventing dpkg from trying to pull arm64 packages from the repo. 

Change was already made in amdgpu-install and is live on ROCm 6.3.0, updating NPM install for parity.