### PR TITLE
Update links to machine learning framework compatibility pages

### DIFF
--- a/docs/install/3rd-party/jax-install.rst
+++ b/docs/install/3rd-party/jax-install.rst
@@ -8,6 +8,12 @@ JAX on ROCm
 
 This directory provides setup instructions and necessary files to build, test, and run JAX with ROCm support in a Docker environment, suitable for both runtime and CI workflows. Explore the following methods to use or build JAX on ROCm.
 
+For hardware, software, and third-party framework compatibility between ROCm and PyTorch, refer to:
+
+* :ref:`system-requirements`
+
+* :doc:`rocm:compatibility/ml-compatibility/jax-compatibility`
+
 Using a prebuilt Docker image
 ===========================================
 

--- a/docs/install/3rd-party/jax-install.rst
+++ b/docs/install/3rd-party/jax-install.rst
@@ -8,7 +8,7 @@ JAX on ROCm
 
 This directory provides setup instructions and necessary files to build, test, and run JAX with ROCm support in a Docker environment, suitable for both runtime and CI workflows. Explore the following methods to use or build JAX on ROCm.
 
-For hardware, software, and third-party framework compatibility between ROCm and PyTorch, refer to:
+For hardware, software, and third-party framework compatibility between ROCm and JAX, see the following resources:
 
 * :ref:`system-requirements`
 

--- a/docs/install/3rd-party/pytorch-install.rst
+++ b/docs/install/3rd-party/pytorch-install.rst
@@ -27,7 +27,7 @@ To install PyTorch for ROCm, you have the following options:
 
    <br/>
 
-For hardware, software, and third-party framework compatibility between ROCm and PyTorch, refer to:
+For hardware, software, and third-party framework compatibility between ROCm and PyTorch, see the following resources:
 
 * :ref:`system-requirements`
 

--- a/docs/install/3rd-party/pytorch-install.rst
+++ b/docs/install/3rd-party/pytorch-install.rst
@@ -30,7 +30,8 @@ To install PyTorch for ROCm, you have the following options:
 For hardware, software, and third-party framework compatibility between ROCm and PyTorch, refer to:
 
 * :ref:`system-requirements`
-* :ref:`3rd-party-support-matrix`
+
+* :doc:`rocm:compatibility/ml-compatibility/pytorch-compatibility`
 
 .. _using-docker-with-pytorch-pre-installed:
 

--- a/docs/install/3rd-party/tensorflow-install.rst
+++ b/docs/install/3rd-party/tensorflow-install.rst
@@ -21,7 +21,7 @@ To install TensorFlow for ROCm, you have the following options:
 
 * :ref:`install-tensorflow-wheels`
 
-For hardware, software, and third-party framework compatibility between ROCm and TensorFlow, refer to:
+For hardware, software, and third-party framework compatibility between ROCm and TensorFlow, see the following resources:
 
 * :ref:`system-requirements`
 

--- a/docs/install/3rd-party/tensorflow-install.rst
+++ b/docs/install/3rd-party/tensorflow-install.rst
@@ -21,6 +21,12 @@ To install TensorFlow for ROCm, you have the following options:
 
 * :ref:`install-tensorflow-wheels`
 
+For hardware, software, and third-party framework compatibility between ROCm and TensorFlow, refer to:
+
+* :ref:`system-requirements`
+
+* :doc:`rocm:compatibility/ml-compatibility/tensorflow-compatibility`
+
 .. note::
 
    As of ROCm 6.1, ``tensorflow-rocm`` packages are found at `<https://repo.radeon.com/rocm/manylinux>`__.


### PR DESCRIPTION
Fix links because the 3rd-party-support-matrix page is deprecated in favor of standalone framework compatibility pages and the main ROCm compatibility matrix.