### PR TITLE
Fix incorrect instructions for configuring groups automatically

### DIFF
--- a/docs/install/prerequisites.rst
+++ b/docs/install/prerequisites.rst
@@ -420,8 +420,7 @@ through Direct Rendering Manager (DRM) render nodes.
    .. code-block:: shell
 
       echo 'ADD_EXTRA_GROUPS=1' | sudo tee -a /etc/adduser.conf
-      echo 'EXTRA_GROUPS=video' | sudo tee -a /etc/adduser.conf
-      echo 'EXTRA_GROUPS=render' | sudo tee -a /etc/adduser.conf
+      echo 'EXTRA_GROUPS=video render' | sudo tee -a /etc/adduser.conf
 
 Using udev rules
 --------------------------------------------------------------------


### PR DESCRIPTION
Currently, only 'render' group is applied to a new user because of incorrect usage of EXTRA_GROUPS configuration.
This change ensures that users configure the both groups correctly, preventing potential misconfigurations.