### PR TITLE
Fix multi-version install instructions [6.4.0]

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -6,7 +6,7 @@
 
 # ROCm version numbers
 rocm_version = '6.4'
-rocm_multi_versions = '6.4.0 6.3.3' # in 6.3, the folder names on repo.radeon.com use 6.3 for minor releases
+rocm_multi_versions = '6.4 6.3.3' # in 6.3, the folder names on repo.radeon.com use 6.3 for minor releases
 rocm_multi_versions_package_versions = '6.4.0 6.3.3' # however, in multi, the packages use 6.3.0
 rocm_directory_version = '6.4.0' # in 6.0 rocm was located in /opt/rocm-6.0.0
 amdgpu_version = '6.4' # directory in https://repo.radeon.com/rocm/apt/ and https://repo.radeon.com/amdgpu-install/

--- a/docs/install/install-methods/includes/debian-multi-install.rst
+++ b/docs/install/install-methods/includes/debian-multi-install.rst
@@ -16,7 +16,7 @@
                .. code-block:: bash
                    :substitutions:
 
-                   ver = |amdgpu_version|
+                   ver=|amdgpu_version|
                    echo "deb [arch=amd64 signed-by=/etc/apt/keyrings/rocm.gpg] https://repo.radeon.com/amdgpu/$ver/ubuntu {{ os_release }} main" \
                        | sudo tee /etc/apt/sources.list.d/amdgpu.list
                    sudo apt update

--- a/docs/install/install-methods/includes/rhel-multi-install.rst
+++ b/docs/install/install-methods/includes/rhel-multi-install.rst
@@ -13,7 +13,7 @@
               .. code-block:: bash
                   :substitutions:
 
-                  ver = |amdgpu_version|
+                  ver=|amdgpu_version|
                   sudo tee /etc/yum.repos.d/amdgpu.repo <<EOF
                   [amdgpu]
                   name=amdgpu

--- a/docs/install/install-methods/includes/sles-multi-install.rst
+++ b/docs/install/install-methods/includes/sles-multi-install.rst
@@ -13,7 +13,7 @@
               .. code-block:: bash
                   :substitutions:
 
-                  ver = |amdgpu_version|
+                  ver=|amdgpu_version|
                   sudo tee /etc/zypp/repos.d/amdgpu.repo <<EOF
                   [amdgpu]
                   name=amdgpu

--- a/docs/install/install-methods/includes/ubuntu-multi-install.rst
+++ b/docs/install/install-methods/includes/ubuntu-multi-install.rst
@@ -16,7 +16,7 @@
                .. code-block:: bash
                    :substitutions:
 
-                   ver = |amdgpu_version|
+                   ver=|amdgpu_version|
                    echo "deb [arch=amd64 signed-by=/etc/apt/keyrings/rocm.gpg] https://repo.radeon.com/amdgpu/$ver/ubuntu {{ os_release }} main" \
                        | sudo tee /etc/apt/sources.list.d/amdgpu.list
                    sudo apt update


### PR DESCRIPTION
Changes:
- Fix spaces in var assignment --> change `ver = 6.4` to `ver=6.4`
  - https://advanced-micro-devices-demo--437.com.readthedocs.build/projects/install-on-linux/en/437/install/install-methods/multi-version-install.html#using-your-package-manager
- Fix repository path --> should be `6.4` instead of `6.4.0` for x.x.0 versions (http://repo.radeon.com/rocm/apt/)
![image](https://github.com/user-attachments/assets/0bd6d0a9-bc7c-479a-a3bb-be69e54afb81)
