### PR TITLE
Add RHEL 9.6 support to installers

### DIFF
--- a/docs/install/rocm-offline-installer.rst
+++ b/docs/install/rocm-offline-installer.rst
@@ -58,7 +58,7 @@ Supported Linux distributions
 The ROCm Offline Installer Creator tool supports the following Linux distributions and versions:
 
 * Ubuntu: 20.04, 22.04, 24.04
-* RHEL: 8.10, 9.4, 9.5
+* RHEL: 8.10, 9.4, 9.5, 9.6
 * SLES: 15.6
 * Debian: 12
 

--- a/docs/install/rocm-runfile-installer.rst
+++ b/docs/install/rocm-runfile-installer.rst
@@ -84,7 +84,7 @@ Supported Linux distributions
 The ROCm Runfile Installer tool supports the following Linux distributions and versions:
 
 *  Ubuntu: 22.04, 24.04
-*  RHEL: 8.10, 9.4, 9.5
+*  RHEL: 8.10, 9.4, 9.5, 9.6
 *  SLES: 15.6
 
 Getting started


### PR DESCRIPTION
Add RHEL 9.6 to the supported Linux distributions for the Offline and Runfile installers.