### PR TITLE
Fix 'Run Docker containers' documentation

### DIFF
--- a/.wordlist.txt
+++ b/.wordlist.txt
@@ -40,6 +40,7 @@ ROCmVersion
 rowspan
 Runfile
 SBR
+seealso
 selectable
 SMCi
 SRIOV

--- a/docs/how-to/docker.rst
+++ b/docs/how-to/docker.rst
@@ -16,7 +16,7 @@ Prerequisites
   kernel-mode driver (``amdgpu-dkms``) must be installed on the host. If you've already installed
   ROCm, you probably already have ``amdgpu-dkms``.
 
-  * :ref:`Check for amdgpu-dkms <verify-dkms>`
+  * `Check for amdgpu-dkms <https://instinct.docs.amd.com/projects/amdgpu-docs/en/latest/install/detailed-install/post-install.html#verify-kernel-mode-driver-installation>`_
 
   * If you don't have ``amdgpu-dkms``, follow the :ref:`standard install instructions<rocm-install-quick>`
     (which comes with ``amdgpu-dkms``) or :ref:`install amdgpu-dkms only<amdgpu-install-dkms>`.

--- a/docs/how-to/docker.rst
+++ b/docs/how-to/docker.rst
@@ -83,7 +83,7 @@ the preceding ``docker run`` command:
           - /dev/kfd
           - /dev/dri
         security_opt:
-          - seccomp:unconfined
+          - seccomp=unconfined
 
 You can then run this using ``docker compose run my-service``.
 

--- a/docs/how-to/docker.rst
+++ b/docs/how-to/docker.rst
@@ -62,12 +62,12 @@ Docker compose
 
 You can also use ``docker compose`` to launch your containers, even when launching a single
 container. This can be a convenient way to run complex Docker commands without having to
-remember all the CLI arguments. Here is a docker-compose file, which is equivalent to the preceding
-``docker run`` command:
+remember all the CLI arguments.
+The following snippet is an example `compose.yaml` file, which is equivalent to
+the preceding ``docker run`` command:
 
 .. code-block:: yaml
 
-    version: "3.7"
     services:
       my-service:
         image: <image>

--- a/docs/how-to/docker.rst
+++ b/docs/how-to/docker.rst
@@ -92,11 +92,18 @@ You can then run this using ``docker compose run my-service``.
 Restricting GPU access
 --------------------------------------------------------------------
 
-By default, passing ``--device /dev/dri`` grant access to all GPUs on the system. To limit a container to a
+By default, passing ``--device /dev/dri`` grants access to all GPUs on the system. To limit a container to a
 specific subset of GPUs, you can instead pass in their individual device nodes.
-By passing ``--device /dev/dri``, you are granting access to all GPUs on the system. In order to limit
-access to a subset of GPUs, you can pass each device individually using one or more
-``-device /dev/dri/renderD<node>``, where ``<node>`` is the card index, starting from 128.
+
+GPU device nodes are located in ``/dev/dri/`` and are typically named ``renderD128``, ``renderD129``, and so on.
+You can list the available GPUs on your host system with the following command:
+
+.. code-block:: shell
+
+   ls /dev/dri/render*
+
+To expose only the first two GPUs to the container, specify them directly in the run command.
+Note that ``/dev/kfd`` is always required for the compute interface.
 
 For example, to expose the first and second GPU:
 
@@ -117,14 +124,14 @@ Docker images in the ROCm ecosystem
 =======================================================
 
 The `ROCm Docker repository <https://github.com/ROCm/ROCm-docker>`_ hosts Dockerfiles useful for
-building your own containers, leveraging ROCm. The built images are available on
+building your own ROCm-capable containers. The built images are available on
 `Docker Hub <https://hub.docker.com/u/rocm>`_. In particular:
 
 * ``rocm/rocm-terminal`` is a small image with the prerequisites to build HIP applications, but does not
   include any libraries.
 
 * `ROCm dev images <https://hub.docker.com/search?q=rocm%2Fdev>`_ provide a variety of OS +
-  ROCm versions, and are a great starting place for building applications
+  ROCm versions, and are a great starting place for building applications.
 
 Applications
 -------------------------------------------------------------------------------------------------

--- a/docs/how-to/docker.rst
+++ b/docs/how-to/docker.rst
@@ -23,7 +23,7 @@ Prerequisites
 
 .. seealso::
 
-   For instructions on installing Docker, see the `official Docker
+   For instructions on installing Docker, see the `official Docker installation
    documentation <https://docs.docker.com/engine/install/>`_.
 
 .. _docker-access-gpus-in-container:
@@ -31,7 +31,9 @@ Prerequisites
 Accessing GPUs in containers
 ==========================================
 
-In order to grant access to GPUs from within a container, run your container with the following options:
+To grant a Docker container access to the host's AMD GPUs, run your container with the following options.
+See the `Docker documentation <https://docs.docker.com/reference/cli/docker/container/run/>`_ to learn
+more about the ``docker run`` command and its options.
 
 .. code-block:: shell
 
@@ -42,6 +44,10 @@ The purpose of each option is as follows:
 * ``--device /dev/kfd``
 
   This is the main compute interface, shared by all GPUs.
+  The Docker CLI's ``--device`` option enables directly exposing host devices
+  to a container. See `Add host device to container (--device)
+  <https://docs.docker.com/reference/cli/docker/container/run/#device>`_ for
+  more information.
 
 * ``--device /dev/dri``
 
@@ -52,6 +58,8 @@ The purpose of each option is as follows:
 
   This option enables memory mapping, and is recommended for containers running in HPC
   environments.
+  See `Optional security options (--security-opt)
+  <https://docs.docker.com/reference/cli/docker/container/run/#security-opt>`_.
 
   The performance of an application can vary depending on the assignment of GPUs and CPUs to the
   task. Typically, ``numactl`` is installed as part of many HPC applications to provide GPU/CPU
@@ -84,6 +92,8 @@ You can then run this using ``docker compose run my-service``.
 Restricting GPU access
 --------------------------------------------------------------------
 
+By default, passing ``--device /dev/dri`` grant access to all GPUs on the system. To limit a container to a
+specific subset of GPUs, you can instead pass in their individual device nodes.
 By passing ``--device /dev/dri``, you are granting access to all GPUs on the system. In order to limit
 access to a subset of GPUs, you can pass each device individually using one or more
 ``-device /dev/dri/renderD<node>``, where ``<node>`` is the card index, starting from 128.
@@ -98,15 +108,15 @@ Verifying the amdgpu driver has been loaded on GPUs
 --------------------------------------------------------------------
 
 ``rocminfo`` is an application for reporting information about the HSA system attributes and agents.
-``rocm-smi`` is a tool that acts as a command line interface for manipulating and monitoring the amdgpu kernel.
+``amd-smi`` is a tool that acts as a command line interface for manipulating and monitoring the amdgpu kernel.
 
-Running ``rocminfo`` and ``rocm-smi`` inside the container will only enumerate the GPUs passed into the docker container.
-Running ``rocminfo`` and ``rocm-smi`` on bare metal will enumerate all ROCm-capable GPUs on the machine.
+Running ``rocminfo`` and ``amd-smi list`` inside the container will only enumerate the GPUs passed into the docker container.
+Running ``rocminfo`` and ``amd-smi list`` on bare metal will enumerate all ROCm-capable GPUs on the machine.
 
 Docker images in the ROCm ecosystem
 =======================================================
 
-The `ROCm Docker repository <https://github.com/ROCm/ROCm-docker>`_ hosts images useful for
+The `ROCm Docker repository <https://github.com/ROCm/ROCm-docker>`_ hosts Dockerfiles useful for
 building your own containers, leveraging ROCm. The built images are available on
 `Docker Hub <https://hub.docker.com/u/rocm>`_. In particular:
 

--- a/docs/how-to/docker.rst
+++ b/docs/how-to/docker.rst
@@ -21,6 +21,11 @@ Prerequisites
   * If you don't have ``amdgpu-dkms``, follow the :ref:`standard install instructions<rocm-install-quick>`
     (which comes with ``amdgpu-dkms``) or :ref:`install amdgpu-dkms only<amdgpu-install-dkms>`.
 
+.. seealso::
+
+   For instructions on installing Docker, see the `official Docker
+   documentation <https://docs.docker.com/engine/install/>`_.
+
 .. _docker-access-gpus-in-container:
 
 Accessing GPUs in containers
@@ -114,6 +119,6 @@ building your own containers, leveraging ROCm. The built images are available on
 Applications
 -------------------------------------------------------------------------------------------------
 
-AMD provides pre-built images for various GPU-ready applications through
-`Infinity Hub <https://www.amd.com/en/technologies/infinity-hub>`_. There, you'll also find examples
+AMD provides pre-built images for various GPU-ready AI and HPC applications through
+`Infinity Hub <https://www.amd.com/en/developer/resources/infinity-hub.html>`_. There, you'll also find examples
 for invoking each application and suggested parameters used for benchmarking.

--- a/docs/how-to/docker.rst
+++ b/docs/how-to/docker.rst
@@ -71,7 +71,7 @@ Docker compose
 You can also use ``docker compose`` to launch your containers, even when launching a single
 container. This can be a convenient way to run complex Docker commands without having to
 remember all the CLI arguments.
-The following snippet is an example `compose.yaml` file, which is equivalent to
+The following snippet is an example ``compose.yaml`` file, which is equivalent to
 the preceding ``docker run`` command:
 
 .. code-block:: yaml

--- a/docs/how-to/spack.rst
+++ b/docs/how-to/spack.rst
@@ -2,9 +2,9 @@
   :description: How to use Spack to install ROCm.
   :keywords: Spack, package management tool, AMD, ROCm
 
-*********
-Use Spack
-*********
+************************************
+Using Spack to install ROCm packages
+************************************
 
 Spack is a package management tool designed to support multiple software
 versions and configurations on a wide variety of platforms and environments. It


### PR DESCRIPTION
https://rocm.docs.amd.com/projects/install-on-linux/en/latest/how-to/docker.html
https://advanced-micro-devices-demo--489.com.readthedocs.build/projects/install-on-linux/en/489/how-to/docker.html

Need to modify:

- `device` to `devices`

- "docker-compose file" to `compose.yaml` file

- remove legacy `version: "3.7"`

QoL updates:

- link to relevant information and troubleshooting tips