### PR TITLE
Update tensorflow-install.rst

### DIFF
--- a/docs/install/3rd-party/tensorflow-install.rst
+++ b/docs/install/3rd-party/tensorflow-install.rst
@@ -79,7 +79,7 @@ Follow these steps:
 
    .. code-block:: shell
 
-       docker run -it 
+       docker run -it \
            --network=host \
            --device=/dev/kfd \
            --device=/dev/dri \


### PR DESCRIPTION
Missing backslash for line continuation was causing the following errors.

```
 docker run -it
    --network=host \
    --device=/dev/kfd \
    --device=/dev/dri \
    --ipc=host \
    --shm-size 16G \
    --group-add video \
    --cap-add=SYS_PTRACE \
    --security-opt seccomp=unconfined \
    rocm/tensorflow:latest
"docker run" requires at least 1 argument.
See 'docker run --help'.

Usage:  docker run [OPTIONS] IMAGE [COMMAND] [ARG...]

Create and run a new container from an image
--network=host: command not found
```
Added backslash to resolve.