### PR TITLE
Replace "Using the PyTorch ROCm base Docker image" with "Building PyTorch from source"

### DIFF
--- a/docs/install/3rd-party/pytorch-install.rst
+++ b/docs/install/3rd-party/pytorch-install.rst
@@ -366,13 +366,13 @@ wheels command, you must select **Linux**, **Python**, **pip**, and **ROCm** in 
 
    .. note::
 
-      The following command uses the ROCm 6.4.0 PyTorch wheel. If you want a different version of ROCm,
+      The following command uses the ROCm 7.0 PyTorch wheel. If you want a different version of ROCm,
       modify the command accordingly.
 
    .. code-block:: bash
       :substitutions:
 
-       pip3 install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/rocm6.4/
+       pip3 install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/rocm7.0
 
 4. (Optional) Use MIOpen kdb files with ROCm PyTorch wheels.
 
@@ -713,7 +713,7 @@ ImageNet PyTorch example
 Troubleshooting
 ===============
 
-* What to do if you get the following error when trying to run PyTorch: 
+* What to do if you get the following error when trying to run PyTorch:
 
   .. code-block:: shell
 
@@ -736,10 +736,10 @@ Troubleshooting
         TORCHDIR=$( dirname $( python3 -c 'import torch; print(torch.__file__)' ) )
         roc-obj-ls -v $TORCHDIR/lib/libtorch_hip.so # check for gfx target
 
-     .. note:: 
+     .. note::
 
         Recompile PyTorch with the right gfx target if compiling from the source if
-        the hardware is not supported. 
+        the hardware is not supported.
 
 * What if you are unable to access Docker or GPU in user accounts?
 
@@ -747,8 +747,8 @@ Troubleshooting
 
 * Can you install PyTorch directly on bare metal?
 
-  Bare-metal installation of PyTorch is supported through wheels. For more information, see :ref:`using-wheels-package`. 
+  Bare-metal installation of PyTorch is supported through wheels. For more information, see :ref:`using-wheels-package`.
 
 * How do you profile PyTorch workloads?
 
-  Use the PyTorch Profiler as described in :ref:`mi300x-pytorch-profiler` to profile GPU kernels on ROCm. 
+  Use the PyTorch Profiler as described in :ref:`mi300x-pytorch-profiler` to profile GPU kernels on ROCm.

--- a/docs/install/3rd-party/pytorch-install.rst
+++ b/docs/install/3rd-party/pytorch-install.rst
@@ -434,11 +434,6 @@ specific ROCm version, GPU architecture, and project requirements.
            --shm-size 8G \
            rocm/pytorch:latest
 
-   .. note::
-
-      You can pass the ``-v`` argument to mount data directories from the host
-      into the container if needed.
-
 3. Uninstall the pre-installed PyTorch inside the container. Otherwise, the prebuilt ROCm PyTorch from the
    container might conflict with your source build.
 
@@ -472,21 +467,11 @@ specific ROCm version, GPU architecture, and project requirements.
 
        export PYTORCH_ROCM_ARCH=<uarch>
 
-   Replace ``<uarch>`` with the result from ``rocminfo`` (for example, ``gfx90a``, ``gfx1030``).
+   Replace ``<uarch>`` with the result from ``rocminfo`` (for example, ``gfx90a``, ``gfx1030``). See :ref:`system-requirements`
+   for the list of AMD GPU architectures.
 
-6. Build PyTorch.
-
-   .. code-block:: bash
-
-       .ci/pytorch/build.sh
-
-   This converts PyTorch sources for HIP compatibility and compiles the framework.
-
-   To verify the build succeeded:
-
-   .. code-block:: bash
-
-       echo $?  # should return 0 if successful
+6. Build and install PyTorch following the instructions in
+   `<https://github.com/pytorch/pytorch?tab=readme-ov-file#install-pytorch>`__.
 
 .. _using-pytorch-upstream-docker-image:
 

--- a/docs/install/3rd-party/pytorch-install.rst
+++ b/docs/install/3rd-party/pytorch-install.rst
@@ -404,6 +404,90 @@ wheels command, you must select **Linux**, **Python**, **pip**, and **ROCm** in 
 
        ./install_kdb_files_for_pytorch_wheels.sh
 
+.. _using-pytorch-rocm-docker-image:
+.. _building-pytorch-from-source:
+
+Building your own PyTorch from source
+=====================================
+
+Use the ``rocm/pytorch:latest`` image, uninstall the preinstalled PyTorch
+package, and rebuild PyTorch from source. This ensures compatibility with your
+specific ROCm version, GPU architecture, and project requirements.
+
+1. Download the latest PyTorch Docker image.
+
+   .. code-block:: bash
+
+       docker pull rocm/pytorch:latest
+
+2. Start a Docker container using the downloaded image.
+
+   .. code-block:: bash
+
+       docker run -it \
+           --cap-add=SYS_PTRACE \
+           --security-opt seccomp=unconfined \
+           --device=/dev/kfd \
+           --device=/dev/dri \
+           --group-add video \
+           --ipc=host \
+           --shm-size 8G \
+           rocm/pytorch:latest
+
+   .. note::
+
+      You can pass the ``-v`` argument to mount data directories from the host
+      into the container if needed.
+
+3. Uninstall the pre-installed PyTorch inside the container. Otherwise, the prebuilt ROCm PyTorch from the
+   container might conflict with your source build.
+
+   .. code-block:: bash
+
+       pip3 uninstall -y torch torchvision torchaudio
+
+4. Clone the PyTorch repository.
+
+   .. code-block:: bash
+
+       cd ~
+       git clone https://github.com/pytorch/pytorch.git
+       cd pytorch
+       git submodule update --init --recursive
+
+5. (Optional) Set your ROCm architecture.
+
+   By default, PyTorch builds for a broad set of AMD architectures. To speed
+   up compilation, you can target only your GPU architecture.
+
+   To determine your architecture:
+
+   .. code-block:: bash
+
+       rocminfo | grep gfx
+
+   Then set the ``PYTORCH_ROCM_ARCH`` environment variable:
+
+   .. code-block:: bash
+
+       export PYTORCH_ROCM_ARCH=<uarch>
+
+   Replace ``<uarch>`` with the result from ``rocminfo`` (for example, ``gfx90a``, ``gfx1030``).
+
+6. Build PyTorch.
+
+   .. code-block:: bash
+
+       .ci/pytorch/build.sh
+
+   This converts PyTorch sources for HIP compatibility and compiles the framework.
+
+   To verify the build succeeded:
+
+   .. code-block:: bash
+
+       echo $?  # should return 0 if successful
+
 .. _using-pytorch-upstream-docker-image:
 
 Using the PyTorch upstream Dockerfile


### PR DESCRIPTION
## Motivation

The rocm/pytorch `latest-base` image is no longer maintained. Replace with a rough equivalent 

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
