### PR TITLE
Remove continuous numbering of tables and figures

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -106,3 +106,6 @@ html_context = {
 }
 
 footnote_backlinks = False
+
+# Disable figure and table numbering
+numfig = False


### PR DESCRIPTION
## Motivation

This PR disables automatic numbering of figures and tables. Due to the way Sphinx works with numbers across subsections, these numbers can be inconsistent and confusing.

## Technical Details

Disables automatic numbering of figures and tables.

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [X] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
