### PR TITLE
Highlight user space == ROCm and kernel space  == amdgpu

### DIFF
--- a/docs/reference/user-kernel-space-compat-matrix.rst
+++ b/docs/reference/user-kernel-space-compat-matrix.rst
@@ -1,20 +1,24 @@
 .. meta::
-  :description: User and AMD GPU Driver (amdgpu) support matrix
+  :description: User and AMD GPU Driver support matrix
   :keywords: Linux support, support matrix, system requirements, user space versions, kernel-mode GPU driver, KMD, AMD, ROCm
 
 *****************************************************************************************
-User and AMD GPU Driver (amdgpu) support matrix
+User and AMD GPU Driver support matrix
 *****************************************************************************************
 
-The AMD GPU Driver (amdgpu) is now distributed separately from the ROCm software stack and is stored under in its own location ``/amdgpu/`` in the package repository at `repo.radeon.com <https://repo.radeon.com/amdgpu/>`_. The first release was designated as AMD GPU Driver (amdgpu) version 30.10. Starting from ROCm™ 6.4.0, forward and backward compatibility between the AMD GPU Driver (amdgpu) and its user space software is provided up to a year apart (assuming hardware support is available in both). For earlier ROCm releases, the compatibility is provided for +/- 2 releases. This table shows the compatibility combinations that are currently supported.
+.. note::
+
+  User space refers to the ROCm software stack, and AMD GPU Driver refers to the ``amdgpu`` kernel module.
+
+The AMD GPU Driver is now distributed separately from the ROCm software stack and is stored under in its own location ``/amdgpu/`` in the package repository at `repo.radeon.com <https://repo.radeon.com/amdgpu/>`_. The first release was designated as AMD GPU Driver version 30.10. Starting from ROCm™ 6.4.0, forward and backward compatibility between the AMD GPU Driver and its user space software is provided up to a year apart (assuming hardware support is available in both). For earlier ROCm releases, the compatibility is provided for +/- 2 releases. This table shows the compatibility combinations that are currently supported.
 
 .. note ::
 
-  The supported user space versions in the following table are accurate as of the time of publication. For the most up-to-date information about AMD GPU Driver (amdgpu) and supported user space versions, see the latest version of this table at `User and AMD GPU Driver (amdgpu) support matrix <https://rocm.docs.amd.com/projects/install-on-linux/en/latest/reference/user-kernel-space-compat-matrix.html>`_.
+  The supported user space versions in the following table are accurate as of the time of publication. For the most up-to-date information about AMD GPU Driver and supported user space versions, see the latest version of this table at `User and AMD GPU Driver support matrix <https://rocm.docs.amd.com/projects/install-on-linux/en/latest/reference/user-kernel-space-compat-matrix.html>`_.
 
 .. csv-table::
   :widths: 30, 70
-  :header: "AMD GPU Driver (amdgpu)", "Supported user space versions"
+  :header: "AMD GPU Driver", "Supported user space versions"
 
     "30.20.x", "6.3.x, 6.4.x, 7.0.x, 7.1.x"
     "30.10.x", "6.2.x, 6.3.x, 6.4.x, 7.0.x, 7.1.x"


### PR DESCRIPTION
## Motivation

Addresses https://github.com/ROCm/rocm-install-on-linux/issues/648.

We're not clear enough in the below page that user space == ROCm version.

https://rocm.docs.amd.com/projects/install-on-linux/en/latest/reference/user-kernel-space-compat-matrix.html
## Technical Details

 Adding in a note to highlight ROCm == user space, amdgpu == kernel space. Removed the extra references to `(amdgpu)` as they're redundant with this heading.

It also might make sense to reference the existing [blog post](https://rocm.blogs.amd.com/ecosystems-and-partners/instinct-gpu-driver/README.html) on this though I'm not sure if the terminology and information is up to date.

The title of this page also isn't very clear - maybe we should stick with "ROCm Toolkit" from the blog post. `User and AMD GPU Driver` vs `ROCm Toolkit and amdgpu driver`. The latter is straight forward, we can delve into the user mode and kernel mode specifics once they land on the page. 

## Submission Checklist

- [X] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
